### PR TITLE
Prefix queries

### DIFF
--- a/ore/accounts/models.py
+++ b/ore/accounts/models.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _t
 import hashlib
-from ore.core.util import UserFilteringQuerySet, prefix_q
+from ore.core.util import UserFilteringQuerySet
 import reversion
 
 
@@ -55,17 +55,17 @@ class OreUser(AbstractBaseUser, PermissionsMixin, Namespace):
     REQUIRED_FIELDS = ['email']
 
     @staticmethod
-    def is_visible_q(prefix, user):
+    def is_visible_q(user):
         if user.is_anonymous():
-            return prefix_q(prefix, status='active')
+            return Q(status='active')
         elif user.is_superuser:
             return Q()
 
         return (
-            prefix_q(prefix, status='active') |
+            Q(status='active') |
             (
-                ~prefix_q(prefix, status='deleted') &
-                prefix_q(prefix, id=user.id)
+                ~Q(status='deleted') &
+                Q(id=user.id)
             )
         )
 

--- a/ore/core/models.py
+++ b/ore/core/models.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.db.models import Q
 from model_utils import Choices
 from model_utils.fields import StatusField
-from ore.core.util import validate_not_prohibited, UserFilteringInheritanceManager, prefix_q, UserFilteringManager
+from ore.core.util import validate_not_prohibited, UserFilteringInheritanceManager, UserFilteringManager
 from ore.core.regexs import EXTENDED_NAME_REGEX
 import reversion
 
@@ -27,19 +27,19 @@ class Namespace(models.Model):
     objects = UserFilteringInheritanceManager()
 
     @staticmethod
-    def is_visible_q(prefix, user):
+    def is_visible_q(user):
         if user.is_anonymous():
-            return prefix_q(prefix, status='active')
+            return Q(status='active')
         elif user.is_superuser:
             return Q()
 
         return (
-            prefix_q(prefix, status='active') |
+            Q(status='active') |
             (
-                ~prefix_q(prefix, status='deleted') &
+                ~Q(status='deleted') &
                 (
-                    prefix_q(prefix, oreuser=user) |
-                    prefix_q(prefix, organization__teams__users=user)
+                    Q(oreuser=user) |
+                    Q(organization__teams__users=user)
                 )
             )
         )
@@ -85,17 +85,17 @@ class Organization(Namespace):
     objects = UserFilteringManager()
 
     @staticmethod
-    def is_visible_q(prefix, user):
+    def is_visible_q(user):
         if user.is_anonymous():
-            return prefix_q(prefix, status='active')
+            return Q(status='active')
         elif user.is_superuser:
             return Q()
 
         return (
-            prefix_q(prefix, status='active') |
+            Q(status='active') |
             (
-                ~prefix_q(prefix, status='deleted') &
-                prefix_q(prefix, teams__users=user)
+                ~Q(status='deleted') &
+                Q(teams__users=user)
             )
         )
 

--- a/ore/core/util.py
+++ b/ore/core/util.py
@@ -15,6 +15,15 @@ def prefix_q(prefix, **kwargs):
         prefix + k: v for k, v in kwargs.items()
     })
 
+def prefix(pre, q, sep='__'):
+    if hasattr(q, 'children'):
+        cloned = q.clone()
+        cloned.children = [prefix(pre, child, sep) for child in q.children]
+        return cloned
+    elif isinstance(q, tuple) and len(q) == 2:
+        return prefix(pre, q[0], sep), q[1]
+    else:
+        return pre + sep + q
 
 class UserFilteringQuerySet(models.QuerySet):
 


### PR DESCRIPTION
The visibility queries are nice, but suffer from some verbosity because the prefix is constantly passed around. I created a method `add_prefix` that adds the the given prefix to the nested queries (in a sort of hacky way). This isn't very extensible (I've yet to make it generic for the entirety of the Django query dsl), but it works even for our relatively complicated nested queries. IMO it makes the visibility queries more readable.

@lukegb 