### PR TITLE
Fix user page title.

### DIFF
--- a/ore/core/templates/core/users/detail.html
+++ b/ore/core/templates/core/users/detail.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% load permissions %}
 {% block title %}
-{{ user.name }}
+{{ oreuser.name }}
 {% endblock %}
 {% block content %}
 <div class="container">


### PR DESCRIPTION
Currently, when I go to ore-staging.spongepowered.org/gratimax while signed in to my user, the tab title is JBYoshi. This should fix it.