### PR TITLE
Align edit button with review alert

### DIFF
--- a/app/views/projects/pages/view.scala.html
+++ b/app/views/projects/pages/view.scala.html
@@ -17,12 +17,13 @@ Documentation page within Project overview.
         <div class="container">
             <div class="row">
                 <div class="col-md-9">
-                    @if(canEditPages) {
-                        <a href="@routes.Pages.showEditor(model.ownerName, model.slug, page.name)"
-                           class="btn btn-edit btn-default pull-right"><i class="fa fa-edit"></i> @messages("page.edit")</a>
-                    }
                     @* Rendered markdown *@
                     <div class="page-content pull-left">
+
+                        @if(canEditPages) {
+                            <a href="@routes.Pages.showEditor(model.ownerName, model.slug, page.name)"
+                            class="btn btn-edit btn-default pull-right"><i class="fa fa-edit"></i> @messages("page.edit")</a>
+                        }
 
                         @if(!model.isReviewed) {
                             <div class="alert alert-info" role="alert">

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -295,11 +295,6 @@ body {
     margin-bottom: 15px;
 }
 
-.btn-edit {
-    position: absolute;
-    right: 20px;
-}
-
 .project-header {
     padding-top: 20px;
     padding-bottom: 10px;


### PR DESCRIPTION
Currently, the 'Edit' button overlaps with the top edge of the 'Needs Review' alert box. This PR aligns the 'Edit' button so that it is placed in the top-right corner of the alert box.
