### PR TITLE
Improve redirection on login/logout

### DIFF
--- a/app/controllers/Actions.scala
+++ b/app/controllers/Actions.scala
@@ -15,8 +15,12 @@ import scala.concurrent.Future
   */
 trait Actions {
 
-  def onUnauthorized(request: RequestHeader)
-  = Redirect(routes.Users.logIn(None, None, Some(request.path)))
+  def onUnauthorized(request: RequestHeader) = {
+    if (request.flash.get("noRedirect").isDefined) {
+      Redirect(routes.Users.logIn(None, None, Some(request.path)))
+    }
+    Redirect(routes.Application.showHome(None, None, None)).withNewSession
+  }
 
   private def projectAction(author: String, slug: String) = new ActionRefiner[Request, ProjectRequest] {
     def refine[A](request: Request[A]) = Future.successful {

--- a/app/controllers/Users.scala
+++ b/app/controllers/Users.scala
@@ -54,7 +54,7 @@ class Users @Inject()(override val messagesApi: MessagesApi, implicit val ws: WS
     * @return Home page
     */
   def logOut(returnPath: Option[String]) = Action { implicit request =>
-    Redirect(AppConf.getString("baseUrl").get + returnPath.getOrElse(request.path)).withNewSession
+    Redirect(AppConf.getString("baseUrl").get + returnPath.getOrElse(request.path)).withNewSession.flashing("noRedirect" -> "true")
   }
 
   /**

--- a/app/views/core/header.scala.html
+++ b/app/views/core/header.scala.html
@@ -87,7 +87,7 @@ The main header displayed on each layout.
                                 }
                                 <li role="separator" class="divider"></li>
                                 <li>
-                                    <a href="@routes.Users.logOut">
+                                    <a href="@routes.Users.logOut(Some(request.path))">
                                         <span class="pull-left">@messages("general.signout")</span>
                                         <i class="pull-right fa fa-sign-out"></i>
                                     </a>

--- a/conf/routes
+++ b/conf/routes
@@ -33,7 +33,7 @@ GET     /api/:version/users/:user                                   @controllers
 
 GET     /                                                           @controllers.Application.showHome(categories: Option[String], q: Option[String], sort: Option[Int])
 GET     /login                                                      @controllers.Users.logIn(sso: Option[String], sig: Option[String], returnUrl: Option[String])
-GET     /logout                                                     @controllers.Users.logOut
+GET     /logout                                                     @controllers.Users.logOut(returnUrl: Option[String])
 
 # ---------- Projects ----------
 


### PR DESCRIPTION
This PR makes the following changes to login/logout redirection:
- Properly redirects the user to their previous page when logging in with `FakeUser` enabled.
- Redirects the user back to their previous page on logout. An explicit `returnUrl` parameter is provided, for future needs.
