### PR TITLE
Fix infinite redirects during failed permission checks.

### DIFF
--- a/app/controllers/Actions.scala
+++ b/app/controllers/Actions.scala
@@ -17,10 +17,9 @@ import scala.concurrent.Future
 trait Actions {
 
   def onUnauthorized(request: RequestHeader) = {
-    request.flash.get("noRedirect") match {
-      case None => Redirect(routes.Users.logIn(None, None, Some(request.path)))
-      case Some(t) => Redirect(routes.Application.showHome(None, None, None))
-    }
+    if (request.flash.get("noRedirect").isEmpty && User.current(request.session).isEmpty)
+      Redirect(routes.Users.logIn(None, None, Some(request.path)))
+    else Redirect(routes.Application.showHome(None, None, None))
   }
 
   private def processProject(project: Project, user: Option[User]): Option[Project] = {


### PR DESCRIPTION
Steps to reproduce:
- Log in to an account that does not have admin access.
- Go to `/admin/queue` or any other `/admin/*` address.

In Firefox, it says "The page isn't redirecting properly: Firefox has detected that the server is redirecting the request for this address in a way that will never complete."

Sorry if I'm not using proper style; this is the first Scala project I've worked on.
