### PR TITLE
Fix download link for version downloads.

### DIFF
--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -317,7 +317,7 @@ class Versions @Inject()(override val messagesApi: MessagesApi, implicit val ws:
       implicit val project = request.project
       withVersion(versionString) { version =>
         Statistics.versionDownloaded(version) { implicit request =>
-          Ok.sendFile(ProjectFiles.uploadPath(author, slug, versionString).toFile)
+          Ok.sendFile(ProjectFiles.uploadPath(author, project.name, versionString).toFile)
         }
       }
     }


### PR DESCRIPTION
When you try to download a specific version of a plugin whose URL does not match the raw name (e.g. if the name contains spaces), the link doesn't work (example: https://ore-staging.spongepowered.org/djxy/Permission-Manager/versions/1.0). These links use the slug for the file name, while all the rest use the project name instead. This PR fixes that.
