### PR TITLE
Use Sponge dropdown style from SpongeHome

### DIFF
--- a/app/assets/stylesheets/_nav.scss
+++ b/app/assets/stylesheets/_nav.scss
@@ -1,55 +1,23 @@
 @import 'utils';
 
 // left nav
+@import 'topbar';
 
-.navbar-nav {
-  margin-top: 0;
-}
+#topbar {
+  font-size: 15px;
 
-.main-dropdown:hover {
-  display: block;
-}
+  .container {
+    max-width: 1110px;
+  }
 
-.main-dropdown {
-  width: 100%;
-  li.active:hover > a { background-color: #d2af08; }
-  i { margin-right: 1em; }
-}
+  a.logo {
+    color: $sponge_yellow;
+    outline: 0;
 
-.navbar-main {
-  @include box-shadow5(0, 2px, 4px, -1px, rgba(0, 0, 0, 0.25));
-  background-color: #333;
-  padding-top: 1px;
-  height: 63px;
-  min-height: 63px;
-  li.dropdown:hover > ul.dropdown-menu { display: block; }
-  .navbar-left li > a { @include padding-vert(10px, 12px); }
-}
-
-.dropdown-sponge:hover {
-  background-color: #222;
-}
-
-.navbar-nav > li > .main-dropdown, .user-dropdown {
-  @include no-box-shadow();
-  border-radius: 0 0 4px 4px;
-  border: 1px solid #e4e4e4;
-}
-
-.navbar-nav > li > .main-dropdown {
-  padding: 10px 0 4px;
-  border-top: none;
-}
-
-.navbar-nav > li > .user-dropdown {
-  width: 200px;
-}
-
-.user-dropdown > li {
-  position: relative;
-  .unread {
-    bottom: 6px;
-    margin-left: 5px;
+    &:hover, &:focus, &:active, &.active {
+      color: $sponge_yellow;
+      outline: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/_sponge_variables.scss
+++ b/app/assets/stylesheets/_sponge_variables.scss
@@ -1,0 +1,39 @@
+/*
+ * This file is part of SpongeHome, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Brand colors
+$sponge_yellow: #f7cf0d;
+$sponge_dark_yellow: #917300;
+$sponge_grey: #333333;
+$sponge_dark_grey: #2b2b2b;
+
+$sponge_headline_font: Montserrat, "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+.sponge-headline {
+  font-family: $sponge_headline_font;
+  font-weight: 700;
+  text-transform: uppercase;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/_topbar.scss
+++ b/app/assets/stylesheets/_topbar.scss
@@ -1,0 +1,176 @@
+/*
+ * This file is part of SpongeHome, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+@import 'sponge_variables';
+
+$sp_logo_offset_x: 0;
+$sp_logo_offset_y: -20px;
+$sp_topbar_height: 63px;
+$sp_logo_width: 200px;
+
+// Fix anchor links
+// TODO: Doesn't work properly for sections
+/*:target:before {
+  content: '';
+  display: block;
+  height: $sp_topbar_height;
+  margin: -$sp_topbar_height 0 0;
+}*/
+
+#topbar {
+  position: fixed;
+  top: $sp_logo_offset_x;
+  z-index: 9999;
+
+  width: 100%;
+  max-width: 1920px;
+  height: $sp_topbar_height;
+
+  background-color: $sponge_grey;
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.25);
+
+  line-height: 19px;
+
+  a {
+    text-decoration: none;
+  }
+
+  .container {
+    position: relative;
+    padding: 0;
+  }
+}
+
+#sp-logo-container {
+  display: inline-block;
+  margin-left: $sp_logo_offset_y;
+
+  cursor: pointer;
+
+  .logo {
+    display: block;
+
+    width: $sp_logo_width;
+    height: $sp_topbar_height;
+
+    padding-left: 20px;
+    padding-top: 11px;
+
+    @extend .sponge-headline;
+
+    * {
+      display: inline-block;
+      vertical-align: middle;
+    }
+
+    img {
+      height: 40px;
+    }
+
+    span {
+      margin-left: 3px;
+      font-size: 23px;
+      letter-spacing: -1px;
+    }
+
+    i {
+      color: gray;
+    }
+  }
+
+  &:hover {
+    background-color: #2a2a2a;
+
+    #sp-logo-menu {
+      display: block;
+    }
+  }
+}
+
+// Left dropdown menu
+#sp-logo-menu {
+  display: none;
+
+  position: absolute;
+  top: $sp_topbar_height;
+  left: $sp_logo_offset_y;
+
+  width: $sp_logo_width;
+}
+
+#sp-logo-dropdown {
+  margin: 0;
+  padding: 10px 0 4px;
+
+  background-color: white;
+
+  border: 1px solid #e4e4e4;
+  border-radius: 0 0 4px 4px;
+
+  * {
+    box-sizing: content-box; // This is magic
+  }
+
+  li, a {
+    display: block;
+  }
+
+  li {
+    padding: 0;
+
+    &.active {
+      // Fix weird 1px border next to active item
+      position: relative;
+      left: -1px;
+      width: $sp_logo_width;
+
+      background-color: $sponge_yellow;
+    }
+  }
+
+  a {
+    padding: 10px 20px 10px 10px;
+    color: #474a54;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.1)
+    }
+  }
+
+  i {
+    padding: 0 10px 0 5px;
+  }
+
+}
+
+@media (max-width: 767px){
+  #sp-logo-container {
+    margin-left: 0;
+  }
+
+  #sp-logo-menu {
+    left: 0;
+  }
+}

--- a/app/views/bootstrap/header.scala.html
+++ b/app/views/bootstrap/header.scala.html
@@ -16,56 +16,41 @@ The main header displayed on each layout.
     Html("data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"" + title + "\"")
 }
 
-<nav id="top" class="navbar-main navbar navbar-fixed-top navbar-inverse">
+<nav id="topbar" class="navbar-main">
     <div class="container">
         <!-- Left navbar -->
-        <ul class="nav navbar-nav navbar-left">
-            <li class="dropdown dropdown-sponge">
-                <a href="@routes.Application.showHome(None, None, None, None)" class="drop-down-toggle disabled"
-                   data-toggle="dropdown">
-                    <img class="logo" src="@config.sponge.getString("logo").get" />
-                    <span class="fa fa-chevron-down"></span>
-                </a>
-
-                <ul class="dropdown-menu main-dropdown" aria-label="maindropdown">
-                    <li>
-                        <a href="https://www.spongepowered.org">
-                            <i class="fa fa-fw fa-home"></i>@messages("general.home")
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://forums.spongepowered.org">
-                            <i class="fa fa-fw fa-comment"></i>@messages("general.forums")
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://github.com/SpongePowered" target="_blank">
-                            <i class="fa fa-fw fa-code"></i>@messages("general.code")
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://docs.spongepowered.org">
-                            <i class="fa fa-fw fa-book"></i>@messages("general.docs")
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://jd.spongepowered.org" target="_blank">
-                            <i class="fa fa-fw fa-graduation-cap"></i>@messages("general.javadocs")
-                        </a>
-                    </li>
-                    <li class="active">
-                        <a href="https://ore-staging.spongepowered.org">
-                            <i class="fa fa-fw fa-plug"></i>@messages("general.plugins")
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://spongepowered.org#downloads">
-                            <i class="fa fa-fw fa-download"></i>@messages("general.getsponge")
-                        </a>
-                    </li>
+        <div id="sp-logo-container">
+            <a class="logo" href="@routes.Application.showHome(None, None, None, None)">
+                <img src="@config.sponge.getString("logo").get">
+                <span>@messages("general.projectName")</span>
+                <i class="fa fa-fw fa-chevron-down"></i>
+            </a>
+            <div id="sp-logo-menu">
+                <ul id="sp-logo-dropdown">
+                    <li><a href="https://www.spongepowered.org">
+                        <i class="fa-fw fa fa-home"></i>@messages("general.home")
+                    </a></li>
+                    <li><a href="https://forums.spongepowered.org">
+                        <i class="fa-fw fa fa-comment"></i>@messages("general.forums")
+                    </a></li>
+                    <li><a href="https://github.com/SpongePowered">
+                        <i class="fa-fw fa fa-code"></i>@messages("general.code")
+                    </a></li>
+                    <li><a href="https://docs.spongepowered.org">
+                        <i class="fa-fw fa fa-book"></i>@messages("general.docs")
+                    </a></li>
+                    <li><a href="https://jd.spongepowered.org">
+                        <i class="fa-fw fa fa-graduation-cap"></i>@messages("general.javadocs")
+                    </a></li>
+                    <li class="active"><a href="@routes.Application.showHome(None, None, None, None)">
+                        <i class="fa-fw fa fa-plug"></i> @messages("general.plugins")
+                    </a></li>
+                    <li><a href="https://www.spongepowered.org/#downloads">
+                        <i class="fa-fw fa fa-download"></i>@messages("general.getsponge")
+                    </a></li>
                 </ul>
-            </li>
-        </ul>
+            </div>
+        </div>
 
         <!-- Right navbar -->
         <ul class="nav navbar-nav navbar-collapse collapse navbar-right">

--- a/app/views/bootstrap/layout.scala.html
+++ b/app/views/bootstrap/layout.scala.html
@@ -19,6 +19,8 @@ this.
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
+        <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet">
+
         <link rel="icon" type="image/png" href="@config.sponge.getString("icon")">
         <link rel="stylesheet" type="text/css" href="@routes.Assets.at("highlight/styles/default.css")" />
         <link rel="stylesheet" type="text/css" href="@routes.Assets.at("stylesheets/fontawesome/font-awesome.css")">

--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -89,7 +89,7 @@ discourse.embed.retryRate   =   60000
 discourse.embed.categorySlug = ore
 
 # Sponge stuff
-sponge.logo = "https://forums-cdn.spongepowered.org/uploads/default/original/2X/7/77fa5f82289385db14561fac384ddea2a84a0070.png"
+sponge.logo = "https://www.spongepowered.org/assets/img/icons/spongie-mark.svg"
 sponge.icon = "https://forums-cdn.spongepowered.org/uploads/default/original/2X/9/9ba706a80e45cf427617525ee2a19fad7bb6b109.png"
 sponge.sponsors.urls = [  "https://billing.creeperhost.net/link.php?id=8", "https://www.enjin.com/", "http://www.multiplaygameservers.com", "https://www.beastnode.com/", "https://serverminer.com/", "https://mcprohosting.com/?promo=Sponge" ]
 sponge.sponsors.logos = [ "creeperhost.svg", "enjin.png", "multiplay.png", "beastnode.png", "serverminer.png", "mcprohosting.png" ]

--- a/conf/messages
+++ b/conf/messages
@@ -1,6 +1,7 @@
 # Strings localized for en-US locale
 
 general.appName                 =   Ore
+general.projectName             =   Sponge
 general.organization            =   SpongePowered
 general.terms                   =   Terms
 general.contact                 =   Contact


### PR DESCRIPTION
I replaced the current left navigation with the complete code from SpongeHome (I've just copied and pasted the needed SCSS files), that should make it easier to update it in the future.

With these changes, Ore will also use the new (uppercase) style for the Sponge dropdown:

![screen shot 2016-10-27 at 13 36 22](https://cloud.githubusercontent.com/assets/3035868/19765749/5cd74c2e-9c4a-11e6-9f81-9c21fd78e30b.png)
