### PR TITLE
Don't include font-awesome into main.css

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -7,7 +7,6 @@
 @import 'project';
 @import 'user';
 @import 'utils';
-@import 'fontawesome/font-awesome';
 
 html {
   position: relative;


### PR DESCRIPTION
This won't work anyway, since font-awesome uses relative addressing to refer to the font location. Since we include the Font Awesome CSS explicitly into every page anyway, this is redundant and has a tendency to cause the icons to blink.