### PR TITLE
Rework how downloads are handled

### DIFF
--- a/app/db/impl/schema.scala
+++ b/app/db/impl/schema.scala
@@ -144,8 +144,9 @@ class DownloadWarningsTable(tag: Tag) extends ModelTable[DownloadWarning](tag, "
   def versionId = column[Int]("version_id")
   def address = column[InetString]("address")
   def downloadId = column[Int]("download_id")
+  def isConfirmed = column[Boolean]("is_confirmed")
 
-  override def * = (id.?, createdAt.?, expiration, token, versionId, address,
+  override def * = (id.?, createdAt.?, expiration, token, versionId, address, isConfirmed,
                     downloadId) <> ((DownloadWarning.apply _).tupled, DownloadWarning.unapply)
 
 }

--- a/app/db/impl/table/ModelKeys.scala
+++ b/app/db/impl/table/ModelKeys.scala
@@ -67,6 +67,7 @@ object ModelKeys {
 
   // DownloadWarning
   val DownloadId            =   new IntKey[DownloadWarning](_.downloadId, _.downloadId)
+  val IsConfirmed           =   new BooleanKey[DownloadWarning](_.isConfirmed, _.isConfirmed)
 
   // Channel
   val Color                 =   new MappedTypeKey[Channel, Color](_.color, _.color)

--- a/app/models/project/DownloadWarning.scala
+++ b/app/models/project/DownloadWarning.scala
@@ -29,10 +29,18 @@ case class DownloadWarning(override val id: Option[Int] = None,
                            token: String,
                            versionId: Int,
                            address: InetString,
+                           private var _isConfirmed: Boolean = false,
                            private var _downloadId: Int = -1) extends OreModel(id, createdAt) with Expirable {
 
   override type M = DownloadWarning
   override type T = DownloadWarningsTable
+
+  def isConfirmed: Boolean = this._isConfirmed
+
+  def setConfirmed(confirmed: Boolean = true) = Defined {
+    this._isConfirmed = confirmed
+    update(IsConfirmed)
+  }
 
   /**
     * Returns the ID of the download this warning was for.

--- a/app/views/projects/versions/list.scala.html
+++ b/app/views/projects/versions/list.scala.html
@@ -79,16 +79,10 @@ Versions page within Project overview.
                                                     <div class="pull-right">
                                                         <span class="date">@prettifyDate(version.createdAt.get)</span>
                                                         <span class="date">@version.humanFileSize</span>
-                                                        <a href="#" class="a-download"
-                                                           data-form="form-download-@version.id.get">
+                                                        <a href="@versionRoutes.download(
+                                                            model.ownerName, model.slug, version.versionString, None)">
                                                             <i title="Download" class="fa fa-download"></i>
                                                         </a>
-                                                        <form action="@versionRoutes.download(
-                                                            model.ownerName, model.slug, version.versionString)"
-                                                              method="post" style="display: none;"
-                                                              id="form-download-@version.id.get">
-                                                            @CSRF.formField
-                                                        </form>
                                                     </div>
                                                 </td>
                                             </tr>

--- a/app/views/projects/versions/unsafeDownload.scala.html
+++ b/app/views/projects/versions/unsafeDownload.scala.html
@@ -7,8 +7,8 @@
 @import views.html.helper.CSRF
 @(project: Project,
   target: Version,
-  origin: Option[String],
-  downloadType: DownloadType)(implicit messages: Messages, request: Request[_], service: ModelService,
+  downloadType: DownloadType,
+  token: String)(implicit messages: Messages, request: Request[_], service: ModelService,
         config: OreConfig, users: UserBase)
 
 @versionRoutes = @{ controllers.project.routes.Versions }
@@ -26,15 +26,15 @@
                     </div>
                     <div class="panel-body">
                         @Html(messages("version.download.confirm.body"))
-                        <a href="@origin.getOrElse(versionRoutes.show(project.ownerName, project.slug, target.name))"
+                        <a href="@versionRoutes.show(project.ownerName, project.slug, target.name)"
                            class="pull-left unsafe-dl-back">
                             <i class="fa fa-arrow-left"></i> @messages("project.back")
                         </a>
                         <button type="submit" form="form-download" class="pull-right btn btn-primary">
                             @messages("general.continue")
                         </button>
-                        <form action="@versionRoutes.downloadUnsafely(
-                            project.ownerName, project.slug, target.name, origin, Some(downloadType.id), None)"
+                        <form action="@versionRoutes.confirmDownload(project.ownerName, project.slug, target.name,
+                            Some(downloadType.id), token)"
                               method="post" style="display: none;" id="form-download">
                             @CSRF.formField
                         </form>

--- a/app/views/projects/versions/view.scala.html
+++ b/app/views/projects/versions/view.scala.html
@@ -108,14 +108,11 @@
                                 }
                             }
 
-                            <button type="submit" form="form-download" class="btn btn-primary">
+                            <a href="@versionRoutes.download(
+                                project.ownerName, project.slug, version.versionString, None)"
+                               class="btn btn-primary">
                                 <i class="fa fa-download"></i> @messages("general.download")
-                            </button>
-                            <form action="@versionRoutes.download(
-                                project.ownerName, project.slug, version.versionString)"
-                                  method="post" style="display: none;" id="form-download">
-                                @CSRF.formField
-                            </form>
+                            </a>
 
                         </div>
                     </div>

--- a/app/views/projects/view.scala.html
+++ b/app/views/projects/view.scala.html
@@ -193,14 +193,11 @@ Base template for Project overview.
                             }
 
                             <!-- Download button -->
-                            <button form="form-download" type="submit" title="@messages("project.download.recommend")"
-                                    data-toggle="tooltip" data-placement="bottom" class="btn btn-primary">
+                            <a href="@versionRoutes.downloadRecommended(project.ownerName, project.slug, None)"
+                               title="@messages("project.download.recommend")" data-toggle="tooltip"
+                               data-placement="bottom" class="btn btn-primary">
                                 <i class="fa fa-download"></i> @messages("general.download")
-                            </button>
-                            <form action="@versionRoutes.downloadRecommended(project.ownerName, project.slug)"
-                                  method="post" style="display: none;" id="form-download">
-                                @CSRF.formField
-                            </form>
+                            </a>
                         </div>
                     }
                 </div>

--- a/conf/evolutions/default/70.sql
+++ b/conf/evolutions/default/70.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+alter table project_version_download_warnings add column is_confirmed boolean not null default false;
+
+# --- !Downs
+
+alter table project_version_download_warnings drop column is_confirmed;

--- a/conf/messages
+++ b/conf/messages
@@ -189,8 +189,12 @@ version.download.confirm.body.plain = \
   This version has not been reviewed by our moderation staff and may not be safe for download.\n\
   Disclaimer: We disclaim all responsibility for any harm to your server or system should you choose not to heed this \
   warning.\n\
-  Please use the following URL to acknowledge this disclaimer and continue to the download:\n\
-  {0}
+  Please use the following curl to acknowledge this disclaimer and continue to the download:\n\
+  curl -O -J -L -d -X "{0}&csrfToken={1}"
+
+version.download.confirm.wget = Sorry, but Ore does not support the use of wget. \
+  Please use the following curl instead:\n\
+  curl -O -J -L "<url>"
 
 channel.name                    =   Channel name
 channel.edit.title              =   Edit channel

--- a/conf/routes
+++ b/conf/routes
@@ -24,10 +24,10 @@ GET     /api/projects/:pluginId                                     @controllers
 GET     /api/projects/:pluginId/versions                            @controllers.ApiController.listVersions(version = "v1", pluginId, channels: Option[String], limit: Option[Int], offset: Option[Int])
 GET     /api/projects/:pluginId/versions/:name                      @controllers.ApiController.showVersion(version = "v1", pluginId, name)
 
-POST    /api/projects/:pluginId/versions/recommended/download       @controllers.project.Versions.downloadRecommendedJarById(pluginId)
-POST    /api/projects/:pluginId/versions/recommended/signature      @controllers.project.Versions.downloadRecommendedSignatureById(pluginId)
-POST    /api/projects/:pluginId/versions/:name/download             @controllers.project.Versions.downloadJarById(pluginId, name)
-POST    /api/projects/:pluginId/versions/:name/signature            @controllers.project.Versions.downloadSignatureById(pluginId, name)
+GET     /api/projects/:pluginId/versions/recommended/download       @controllers.project.Versions.downloadRecommendedJarById(pluginId, token: Option[String])
+GET     /api/projects/:pluginId/versions/recommended/signature      @controllers.project.Versions.downloadRecommendedSignatureById(pluginId)
+GET     /api/projects/:pluginId/versions/:name/download             @controllers.project.Versions.downloadJarById(pluginId, name, token: Option[String])
+GET     /api/projects/:pluginId/versions/:name/signature            @controllers.project.Versions.downloadSignatureById(pluginId, name)
 
 GET     /api/users                                                  @controllers.ApiController.listUsers(version = "v1", limit: Option[Int], offset: Option[Int])
 GET     /api/users/:user                                            @controllers.ApiController.showUser(version = "v1", user)
@@ -139,16 +139,16 @@ GET     /:author/:slug/versions                                     @controllers
 POST    /:author/:slug/versions/:version/approve                    @controllers.project.Versions.approve(author, slug, version)
 POST    /:author/:slug/versions/:version/delete                     @controllers.project.Versions.delete(author, slug, version)
 
-GET     /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.showDownloadConfirm(author, slug, version, origin: Option[String], downloadType: Option[Int])
-POST    /:author/:slug/versions/:version/unsafe                     @controllers.project.Versions.downloadUnsafely(author, slug, version, origin: Option[String], downloadType: Option[Int], token: Option[String])
+GET     /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.showDownloadConfirm(author, slug, version, downloadType: Option[Int])
+POST    /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.confirmDownload(author, slug, version, downloadType: Option[Int], token)
 
-POST    /:author/:slug/versions/recommended/download                @controllers.project.Versions.downloadRecommended(author, slug)
-POST    /:author/:slug/versions/recommended/signature               @controllers.project.Versions.downloadRecommendedSignature(author, slug)
-POST    /:author/:slug/versions/:version/download                   @controllers.project.Versions.download(author, slug, version)
+GET     /:author/:slug/versions/recommended/download                @controllers.project.Versions.downloadRecommended(author, slug, token: Option[String])
+GET     /:author/:slug/versions/recommended/signature               @controllers.project.Versions.downloadRecommendedSignature(author, slug)
+GET     /:author/:slug/versions/:version/download                   @controllers.project.Versions.download(author, slug, version, token: Option[String])
 GET     /:author/:slug/versions/:version/signature                  @controllers.project.Versions.downloadSignature(author, slug, version)
 
-POST    /:author/:slug/versions/recommended/jar                     @controllers.project.Versions.downloadRecommendedJar(author, slug)
-POST    /:author/:slug/versions/:version/jar                        @controllers.project.Versions.downloadJar(author, slug, version)
+GET     /:author/:slug/versions/recommended/jar                     @controllers.project.Versions.downloadRecommendedJar(author, slug, token: Option[String])
+GET     /:author/:slug/versions/:version/jar                        @controllers.project.Versions.downloadJar(author, slug, version, token: Option[String])
 
 GET     /:author/:slug/versions/new                                 @controllers.project.Versions.showCreator(author, slug)
 POST    /:author/:slug/versions/new/upload                          @controllers.project.Versions.upload(author, slug)


### PR DESCRIPTION
Closes #225, #221, #222

Making a PR for @lukegb to verify that the route changes won't break nginx

Notable changes:
* Change download routes back to GET
* Add an additional POST route for confirmation
* Removes wget support (use curl instead)

The proper way to download via curl is now with the following:

`curl -O -J -L https://ore.spongepowered.org/:user/:project/versions/:version/download`

this will prompt you to follow another curl if you need confirmation which will look something like this:

```
This version has not been reviewed by our moderation staff and may not be safe for download.
  Disclaimer: We disclaim all responsibility for any harm to your server or system should you choose not to heed this warning.
  Please use the following curl to acknowledge this disclaimer and continue to the download:
  curl -O -J -L -d -X "http://localhost:9000/windy/Ore-Test-Plugin/versions/1.0.1/confirm?downloadType=0&token=ffc3d0c0-9794-4ef2-ad56-8230ac351e9c&csrfToken=2f67c0a364624624568343d3d9fe8558298b3443-1488253345270-78f69f1ba7a3adc24d920a47"
```

Signed-off-by: Walker Crouse <walkercrouse@hotmail.com>