### PR TITLE
Fix displayed PGP expiration date

### DIFF
--- a/app/security/pgp/PGPPublicKeyInfo.scala
+++ b/app/security/pgp/PGPPublicKeyInfo.scala
@@ -60,7 +60,7 @@ object PGPPublicKeyInfo {
           val isMaster = key.isMasterKey
           val validSeconds = key.getValidSeconds
           val expirationDate = if (validSeconds != 0)
-            Some(new Date(new Date().getTime + Math.round(validSeconds / 1000f)))
+            Some(new Date(createdAt.getTime + validSeconds * 1000))
           else
             None
 


### PR DESCRIPTION
The current code assumed `getValidSeconds` returns the time from now, but it actually returns the seconds from the creation date.

Fixes #185 