### PR TITLE
Replace pegdown with flexmark

### DIFF
--- a/app/controllers/project/Pages.scala
+++ b/app/controllers/project/Pages.scala
@@ -67,7 +67,7 @@ class Pages @Inject()(forms: OreForms,
     * @return Rendered content
     */
   def showPreview() = Action { implicit request =>
-    Ok(Page.MarkdownProcessor.markdownToHtml((request.body.asJson.get \ "raw").as[String]))
+    Ok(Page.Render((request.body.asJson.get \ "raw").as[String]))
   }
 
   /**

--- a/app/models/project/Version.scala
+++ b/app/models/project/Version.scala
@@ -107,7 +107,7 @@ case class Version(override val id: Option[Int] = None,
     * @return Description in html
     */
   def descriptionHtml: Html
-  = this.description.map(str => Html(Page.MarkdownProcessor.markdownToHtml(str))).getOrElse(Html(""))
+  = this.description.map(str => Page.Render(str)).getOrElse(Html(""))
 
   /**
     * Returns the base URL for this Version.

--- a/build.sbt
+++ b/build.sbt
@@ -27,10 +27,17 @@ libraryDependencies ++= Seq(
   "org.postgresql"        %   "postgresql"              %   "9.4.1212.jre7",
   "com.github.tminglei"   %%  "slick-pg"                %   "0.12.0",
   "org.apache.commons"    %   "commons-io"              %   "1.3.2",
-  "org.pegdown"           %   "pegdown"                 %   "1.6.0",
   "com.getsentry.raven"   %   "raven-logback"           %   "7.2.2",
   "org.bouncycastle"      %   "bcprov-jdk15on"          %   "1.56",
   "org.bouncycastle"      %   "bcpkix-jdk15on"          %   "1.56",
   "org.bouncycastle"      %   "bcpg-jdk15on"            %   "1.56",
-  "javax.mail"            %   "mail"                    %   "1.4.7"
+  "javax.mail"            %   "mail"                    %   "1.4.7",
+
+  "com.vladsch.flexmark"  % "flexmark"                       %  "0.18.0",
+  "com.vladsch.flexmark"  % "flexmark-ext-autolink"          %  "0.18.0",
+  "com.vladsch.flexmark"  % "flexmark-ext-anchorlink"        %  "0.18.0",
+  "com.vladsch.flexmark"  % "flexmark-ext-gfm-strikethrough" %  "0.18.0",
+  "com.vladsch.flexmark"  % "flexmark-ext-gfm-tasklist"      %  "0.18.0",
+  "com.vladsch.flexmark"  % "flexmark-ext-tables"            %  "0.18.0",
+  "com.vladsch.flexmark"  % "flexmark-ext-typographic"       %  "0.18.0"
 )


### PR DESCRIPTION
Pegdown [is deprecated](https://github.com/sirthias/pegdown#-deprecation-note-), they recommend using [flexmark-java](https://github.com/vsch/flexmark-java) instead which seems to work nicely.

Fixes #212 and should improve the overall rendering performance (according to the description it is about 30x faster).