### PR TITLE
Replace all usages of commons-io with NIO methods

### DIFF
--- a/app/controllers/project/Projects.scala
+++ b/app/controllers/project/Projects.scala
@@ -13,7 +13,6 @@ import ore.project.factory.ProjectFactory
 import ore.project.io.{InvalidPluginFileException, PluginUpload}
 import ore.user.MembershipDossier._
 import ore.{OreConfig, OreEnv, StatTracker}
-import org.apache.commons.io.FileUtils
 import play.api.i18n.MessagesApi
 import play.api.mvc._
 import security.spauth.SingleSignOnConsumer
@@ -248,7 +247,7 @@ class Projects @Inject()(stats: StatTracker,
     }
   }
 
-  private def showImage(path: Path) = Ok(FileUtils.readFileToByteArray(path.toFile)).as("image/jpeg")
+  private def showImage(path: Path) = Ok(Files.readAllBytes(path)).as("image/jpeg")
 
   /**
     * Submits a flag on the specified project for further review.

--- a/app/db/impl/access/ProjectBase.scala
+++ b/app/db/impl/access/ProjectBase.scala
@@ -10,8 +10,8 @@ import discourse.OreDiscourseApi
 import models.project.{Channel, Project, Version}
 import ore.project.io.ProjectFiles
 import ore.{OreConfig, OreEnv}
-import org.apache.commons.io.FileUtils
 import play.api.Logger
+import util.FileUtils
 import util.StringUtils._
 
 class ProjectBase(override val service: ModelService,
@@ -82,7 +82,7 @@ class ProjectBase(override val service: ModelService,
       val iconDir = this.fileManager.getIconDir(project.ownerName, project.name)
       if (notExists(iconDir))
         createDirectories(iconDir)
-      FileUtils.cleanDirectory(iconDir.toFile)
+      FileUtils.cleanDirectory(iconDir)
       move(iconPath, iconDir.resolve(iconPath.getFileName))
     }
   }
@@ -122,7 +122,7 @@ class ProjectBase(override val service: ModelService,
     checkArgument(channel.versions.isEmpty ||
       channels.count(c => c.versions.nonEmpty) > 1, "last non-empty channel", "")
 
-    FileUtils.deleteDirectory(this.fileManager.getProjectDir(proj.ownerName, proj.name).resolve(channel.name).toFile)
+    FileUtils.deleteDirectory(this.fileManager.getProjectDir(proj.ownerName, proj.name).resolve(channel.name))
     channel.remove()
   }
 
@@ -166,7 +166,7 @@ class ProjectBase(override val service: ModelService,
     * @param project Project to delete
     */
   def delete(project: Project) = {
-    FileUtils.deleteDirectory(this.fileManager.getProjectDir(project.ownerName, project.name).toFile)
+    FileUtils.deleteDirectory(this.fileManager.getProjectDir(project.ownerName, project.name))
     if (project.topicId != -1)
       this.forums.deleteProjectTopic(project)
     // TODO: Instead, move to the "projects_deleted" table just in case we couldn't delete the topic

--- a/app/models/project/Version.scala
+++ b/app/models/project/Version.scala
@@ -15,8 +15,8 @@ import models.statistic.VersionDownload
 import ore.Visitable
 import ore.permission.scope.ProjectScope
 import ore.project.Dependency
-import org.apache.commons.io.FileUtils
 import play.twirl.api.Html
+import util.FileUtils
 
 /**
   * Represents a single version of a Project.
@@ -181,7 +181,7 @@ case class Version(override val id: Option[Int] = None,
     *
     * @return Human readable file size
     */
-  def humanFileSize: String = FileUtils.byteCountToDisplaySize(this.fileSize)
+  def humanFileSize: String = FileUtils.formatFileSize(this.fileSize)
 
   /**
     * Returns true if a project ID is defined on this Model, there is no

--- a/app/util/DataHelper.scala
+++ b/app/util/DataHelper.scala
@@ -11,7 +11,6 @@ import models.project.{Channel, Project, ProjectSettings, Version}
 import models.user.User
 import ore.OreConfig
 import ore.project.factory.ProjectFactory
-import org.apache.commons.io.FileUtils
 import play.api.cache.CacheApi
 
 /**
@@ -42,7 +41,7 @@ final class DataHelper @Inject()(config: OreConfig,
     Logger.info(s"Deleting ${this.users.size} users...")
     this.users.removeAll()
     Logger.info("Clearing disk...")
-    FileUtils.deleteDirectory(this.factory.env.uploads.toFile)
+    FileUtils.deleteDirectory(this.factory.env.uploads)
     Logger.info("Done.")
   }
 

--- a/app/util/FileUtils.scala
+++ b/app/util/FileUtils.scala
@@ -1,0 +1,81 @@
+package util
+
+import java.io.IOException
+import java.lang.Long.numberOfLeadingZeros
+import java.nio.file._
+import java.nio.file.attribute.BasicFileAttributes
+
+object FileUtils {
+
+  /**
+    * Formats the number of bytes into a human readable file size
+    * (e.g. 100.0 KB).
+    *
+    * Based on http://stackoverflow.com/a/24805871
+    *
+    * @param size The size in bytes
+    * @return The formatted string
+    */
+  def formatFileSize(size: Long): String = {
+    if (size < 1024) return s"$size B"
+    val z = (63 - numberOfLeadingZeros(size)) / 10
+    f"${size.toDouble / (1L << (z * 10))}%.1f ${" KMGTPE".charAt(z)}%sB"
+  }
+
+  /**
+    * Deletes the directory at the specified [[Path]] with all of its contents.
+    *
+    * @param dir The directory to delete
+    */
+  def deleteDirectory(dir: Path): Unit = {
+    Files.walkFileTree(dir, DeleteFileVisitor)
+  }
+
+  /**
+    * Deletes the contents of a directory without deleteing the directory itself.
+    *
+    * @param dir The directory to clean
+    */
+  def cleanDirectory(dir: Path): Unit = {
+    Files.walkFileTree(dir, new CleanFileVisitor(dir))
+  }
+
+  /**
+    * Represents a [[java.nio.file.FileVisitor]] which will recursively delete a directory
+    * with all its contents.
+    */
+  private class DeleteFileVisitor extends SimpleFileVisitor[Path] {
+
+    override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      Files.delete(file)
+      FileVisitResult.CONTINUE
+    }
+
+    override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+      Files.delete(dir)
+      FileVisitResult.CONTINUE
+    }
+
+  }
+
+  private object DeleteFileVisitor extends DeleteFileVisitor
+
+  /**
+    * Similar to [[DeleteFileVisitor]], except that it will only clean the folder
+    * contents. It will not delete the given [[dir]].
+    *
+    * @param dir The directory to clean
+    */
+  private class CleanFileVisitor(private val dir: Path) extends DeleteFileVisitor {
+
+    override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+      if (dir != this.dir) {
+        super.postVisitDirectory(dir, exc)
+      } else {
+        FileVisitResult.CONTINUE
+      }
+    }
+
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.play"     %%  "play-slick-evolutions"   %   "2.0.2",
   "org.postgresql"        %   "postgresql"              %   "9.4.1212.jre7",
   "com.github.tminglei"   %%  "slick-pg"                %   "0.12.0",
-  "org.apache.commons"    %   "commons-io"              %   "1.3.2",
   "org.pegdown"           %   "pegdown"                 %   "1.6.0",
   "com.getsentry.raven"   %   "raven-logback"           %   "7.2.2",
   "org.bouncycastle"      %   "bcprov-jdk15on"          %   "1.56",


### PR DESCRIPTION
commons-io is pretty old and requires converting the `Path` to file every time it is used. The current usages can be also written using the Java NIO API with a few more lines:

- `FileUtils.toByteArray(File)` can be replaced with `Files.readAllBytes`
- To delete a complete directory we need to define a custom `FileVisitor` and then walk the file tree.
- `IOUtils.toByteArray` can be replaced with Guava's `ByteStreams.toByteArray`
- I've replaced `byteCountToDisplaySize` with a custom method. Compared to the method from `commons-io`, it is probably a bit faster and it will also add a single decimal place which is the way it is displayed in most other applications, (e.g. `15.9 GB` instead of `15 GB`). In case someone wants to upload a 5 TB plugin this is also handled now... 😆 