### PR TITLE
Set some HTTP security headers

### DIFF
--- a/app/Filters.scala
+++ b/app/Filters.scala
@@ -2,5 +2,8 @@ import javax.inject.Inject
 
 import play.api.http.DefaultHttpFilters
 import play.filters.csrf.CSRFFilter
+import play.filters.headers.SecurityHeadersFilter
+import security.NonceFilter
 
-class Filters @Inject()(csrfFilters: CSRFFilter) extends DefaultHttpFilters(csrfFilters)
+class Filters @Inject()(csrfFilters: CSRFFilter, securityHeadersFilter: SecurityHeadersFilter, nonceFilter: NonceFilter)
+  extends DefaultHttpFilters(csrfFilters, nonceFilter, securityHeadersFilter)

--- a/app/security/NonceFilter.scala
+++ b/app/security/NonceFilter.scala
@@ -1,0 +1,33 @@
+package security
+
+import java.security.SecureRandom
+import java.util.Base64
+import javax.inject.Inject
+
+import akka.stream.Materializer
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import scala.concurrent.Future
+
+object NonceFilter {
+  def nonce(implicit request: RequestHeader): String = request.tags("nonce")
+}
+
+class NonceFilter @Inject() (implicit val mat: Materializer) extends Filter {
+  private val random = new SecureRandom()
+
+  override def apply(next: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
+    val nonce = generateNonce
+    next(request.withTag("nonce", nonce)).map { result =>
+      result.withHeaders("Content-Security-Policy" -> result.header.headers("Content-Security-Policy")
+        .replace("%NONCE-SOURCE%", s"nonce-$nonce"))
+    }
+  }
+
+  private def generateNonce: String = {
+    val bytes = new Array[Byte](16) // 128 bit, see https://w3c.github.io/webappsec-csp/#security-nonces
+    random.nextBytes(bytes)
+    Base64.getEncoder.encodeToString(bytes)
+  }
+}

--- a/app/views/bootstrap/layout.scala.html
+++ b/app/views/bootstrap/layout.scala.html
@@ -6,6 +6,7 @@ this.
 @import db.impl.access.UserBase
 @import ore.OreConfig
 @import play.twirl.api.Html
+@import security.NonceFilter._
 @(title: String, scripts: Boolean = true, header: Boolean = true, user: Boolean = true,
         footer: Boolean = true)(content: Html)(implicit messages: Messages, request: Request[_], service: ModelService,
         config: OreConfig, users: UserBase)
@@ -56,7 +57,7 @@ this.
             <script type="text/javascript" src="@routes.Assets.at("bootstrap/js/bootstrap.min.js")"></script>
             <script type="text/javascript" src="@routes.Assets.at("lib/filesize/lib/filesize.min.js")"></script>
             <script type="text/javascript" src="@routes.Assets.at("highlight/highlight.pack.js")"></script>
-            <script>var caching = @config.ore.getBoolean("caching").get;</script>
+            <script nonce="@nonce">var caching = @config.ore.getBoolean("caching").get;</script>
             <script type="text/javascript" src="@routes.Assets.at("javascripts/main.js")"></script>
             <script type="text/javascript" src="@routes.Assets.at("javascripts/svg.js")"></script>
             <script type="text/javascript" src="@routes.Assets.at("javascripts/spongie.js")"></script>
@@ -64,18 +65,8 @@ this.
                 <script type="text/javascript" src="@routes.Assets.at("javascripts/offline.js")"></script>
             }
             @if(request != null) {
-                <script>csrf = '@play.filters.csrf.CSRF.getToken.get.value'</script>
+                <script nonce="@nonce">csrf = '@play.filters.csrf.CSRF.getToken.get.value'</script>
             }
-            <script>hljs.initHighlightingOnLoad();</script>
-            <script>
-                    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-                    ga('create', 'UA-59476017-3', 'auto');
-                    ga('send', 'pageview');
-            </script>
         }
 
     </body>

--- a/app/views/errors/offline.scala.html
+++ b/app/views/errors/offline.scala.html
@@ -1,6 +1,7 @@
 @import db.ModelService
 @import db.impl.access.UserBase
 @import ore.{OreConfig, OreEnv}
+@import security.NonceFilter._
 @()(implicit messages: Messages, session: Session, request: Request[_] = null, service: ModelService, config: OreConfig,
         users: UserBase, env: OreEnv)
 
@@ -12,7 +13,7 @@
         <i class="minor">@messages("error.offline.body")</i>
     </div>
 
-    <script>
+    <script nonce="@nonce">
         // we do not want to show the offline alert of this page
         var IS_OFFLINE_PAGE = true;
     </script>

--- a/app/views/home.scala.html
+++ b/app/views/home.scala.html
@@ -6,14 +6,14 @@ sorted according to different criteria.
 @import db.ModelService
 @import db.impl.access.UserBase
 @import models.project.Project
-@import ore.OreConfig
+@import ore.{OreConfig, Platforms}
+@import ore.Platforms.Platform
 @import ore.project.Categories._
 @import ore.project.ProjectSortingStrategies.{values, _}
 @import ore.project.{Categories, ProjectSortingStrategies}
+@import security.NonceFilter._
 
 @import scala.util.Random
-@import ore.Platforms
-@import ore.Platforms.Platform
 @(models: Seq[Project], visibleCategories: Option[Array[Category]], query: Option[String], page: Int,
         sort: ProjectSortingStrategy, platform: Option[Platform])(implicit messages: Messages, flash: Flash,
         request: Request[_], service: ModelService, config: OreConfig, users: UserBase)
@@ -52,7 +52,7 @@ sorted according to different criteria.
 @bootstrap.layout(messages("general.title")) {
 
     <script type="text/javascript" src="@routes.Assets.at("javascripts/home.js")"></script>
-    <script>
+    <script nonce="@nonce">
         @if(visibleCategories.isDefined) {
             CATEGORY_STRING = "@visibleCategories.get.map(_.id).mkString(",")";
         }

--- a/app/views/projects/channels/list.scala.html
+++ b/app/views/projects/channels/list.scala.html
@@ -2,8 +2,8 @@
 @import db.impl.access.UserBase
 @import models.project.{Channel, Project}
 @import ore.OreConfig
-@import views.html.helper.form
-@import views.html.helper.CSRF
+@import security.NonceFilter._
+@import views.html.helper.{CSRF, form}
 @(project: Project, channels: Seq[Channel])(implicit messages: Messages, flash: Flash, request: Request[_],
         service: ModelService, config: OreConfig, users: UserBase)
 
@@ -22,7 +22,7 @@
 @bootstrap.layout(messages("channel.list.page-title", project.ownerName, project.slug)) {
 
     <script type="text/javascript" src="@routes.Assets.at("javascripts/channelManage.js")"></script>
-    <script>
+    <script nonce="@nonce">
         PROJECT_OWNER = '@project.ownerName';
         PROJECT_SLUG = '@project.slug';
         $(function() {
@@ -96,7 +96,7 @@
                                         </div>
                                       </td>
                                   </tr>
-                                    <script>
+                                    <script nonce="@nonce">
                                       $(function() {
                                           initChannelDelete('#channel-delete-@channel.id', '@channel.name', @channel.versions.size);
                                           initChannelManager(

--- a/app/views/projects/create.scala.html
+++ b/app/views/projects/create.scala.html
@@ -7,10 +7,8 @@ Page used for uploading and creating new projects.
 @import ore.OreConfig
 @import ore.project.factory.PendingProject
 @import play.twirl.api.Html
-@import views.html.helper.form
-@import ore.project.Dependency
-@import ore.project.Dependency._
-@import views.html.helper.CSRF
+@import security.NonceFilter._
+@import views.html.helper.{CSRF, form}
 @(pending: Option[PendingProject])(implicit messages: Messages, flash: Flash, request: Request[_],
         service: ModelService, config: OreConfig, users: UserBase)
 
@@ -102,7 +100,7 @@ Page used for uploading and creating new projects.
                         </tbody>
                     </table>
 
-                    <script>
+                    <script nonce="@nonce">
                         $(function() {
                             validateMeta("@project.pluginId", "@project.name",
                                     "@project.ownerName", "@project.slug");

--- a/app/views/projects/discuss.scala.html
+++ b/app/views/projects/discuss.scala.html
@@ -7,19 +7,20 @@ Discussion page within Project overview.
 @import models.project.Project
 @import ore.OreConfig
 @import org.spongepowered.play.discourse.DiscourseApi
+@import security.NonceFilter._
 @(model: Project)(implicit messages: Messages, request: Request[_], flash: Flash, service: ModelService,
         forums: DiscourseApi, config: OreConfig, users: UserBase)
 
 @projects.view(model, "#discussion") {
 
-    <script>
+    <script nonce="@nonce">
         DiscourseEmbed = {
             discourseUrl: '@config.forums.getString("baseUrl").get/',
             topicId: @model.topicId
         };
     </script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/projectDiscuss.js")"></script>
-    <script>$(function() { $('.btn-edit').click(); });</script>
+    <script nonce="@nonce">$(function() { $('.btn-edit').click(); });</script>
 
     <div class="container">
         <div id='discourse-comments'></div>

--- a/app/views/projects/pages/modalPageCreate.scala.html
+++ b/app/views/projects/pages/modalPageCreate.scala.html
@@ -1,9 +1,10 @@
 @import controllers.project.{routes => projectRoutes}
 @import models.project.Project
-@(model: Project)(implicit messages: Messages)
+@import security.NonceFilter._
+@(model: Project)(implicit messages: Messages, request: RequestHeader)
 
 <script type="text/javascript" src="@routes.Assets.at("javascripts/pageEdit.js")"></script>
-<script>
+<script nonce="@nonce">
     PROJECT_OWNER = '@model.ownerName';
     PROJECT_SLUG = '@model.slug';
 </script>

--- a/app/views/projects/pages/view.scala.html
+++ b/app/views/projects/pages/view.scala.html
@@ -9,6 +9,7 @@ Documentation page within Project overview.
 @import models.project.{Page, Project}
 @import ore.OreConfig
 @import ore.permission.EditPages
+@import security.NonceFilter._
 @import util.StringUtils._
 @(model: Project, page: Page, editorOpen: Boolean = false)(implicit messages: Messages, request: Request[_],
         flash: Flash, service: ModelService, config: OreConfig, userBase: UserBase)
@@ -20,7 +21,7 @@ Documentation page within Project overview.
 @projects.view(model, "#docs") {
 
     @if(editorOpen) {
-        <script>$(function() { $('.btn-edit').click(); });</script>
+        <script nonce="@nonce">$(function() { $('.btn-edit').click(); });</script>
     }
 
     <div class="project-wiki">

--- a/app/views/projects/settings.scala.html
+++ b/app/views/projects/settings.scala.html
@@ -4,8 +4,8 @@
 @import ore.OreConfig
 @import ore.permission.HideProjects
 @import ore.permission.scope.GlobalScope
-@import views.html.helper.form
-@import views.html.helper.CSRF
+@import security.NonceFilter._
+@import views.html.helper.{CSRF, form}
 @(project: Project)(implicit messages: Messages, flash: Flash, request: Request[_], service: ModelService,
         config: OreConfig, userBase: UserBase)
 
@@ -17,7 +17,7 @@
 
     <script type="text/javascript" src="@routes.Assets.at("javascripts/hideProject.js")"></script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/iconUpload.js")"></script>
-    <script>
+    <script nonce="@nonce">
         projectName = "@project.name";
         PROJECT_OWNER = "@project.ownerName";
         PROJECT_SLUG = "@project.slug";

--- a/app/views/projects/versions/create.scala.html
+++ b/app/views/projects/versions/create.scala.html
@@ -4,9 +4,9 @@
 @import models.project.{Channel, Project}
 @import ore.OreConfig
 @import ore.project.factory.PendingVersion
+@import security.NonceFilter._
 @import util.StringUtils
-@import views.html.helper.form
-@import views.html.helper.CSRF
+@import views.html.helper.{CSRF, form}
 @(project: Project, pending: Option[PendingVersion],
   channels: Option[Seq[Channel]], showFileControls: Boolean)(implicit messages: Messages, flash: Flash,
         request: Request[_], service: ModelService, config: OreConfig, users: UserBase)
@@ -82,7 +82,7 @@
                                                     </a>
                                                     <script type="text/javascript"
                                                             src="@routes.Assets.at("javascripts/versionCreateChannelNew.js")"></script>
-                                                    <script>DEFAULT_COLOR = '@config.defaultChannelColor.hex';</script>
+                                                    <script nonce="@nonce">DEFAULT_COLOR = '@config.defaultChannelColor.hex';</script>
                                                 } else {
                                                     <span id="channel-name" class="channel" style="background-color: @pending.get.channelColor;">
                                                         @pending.get.channelName
@@ -91,7 +91,7 @@
                                                         <i id="channel-edit" class="fa fa-edit"
                                                            data-toggle="modal" data-target="#channel-settings"></i>
                                                     </a>
-                                                    <script>
+                                                    <script nonce="@nonce">
                                                         $(function() {
                                                             // Setup editor
                                                             initChannelManager(
@@ -134,7 +134,7 @@
                                             )
                                         </div>
                                     </div>
-                                    <script>$(function () { $('.btn-edit').click() });</script>
+                                    <script nonce="@nonce">$(function () { $('.btn-edit').click() });</script>
                                 }
                             }
                         }

--- a/app/views/projects/versions/list.scala.html
+++ b/app/views/projects/versions/list.scala.html
@@ -6,8 +6,8 @@ Versions page within Project overview.
 @import models.project.{Channel, Project, Version}
 @import ore.OreConfig
 @import ore.permission.{EditChannels, EditVersions}
+@import security.NonceFilter._
 @import util.StringUtils._
-@import views.html.helper.CSRF
 @(model: Project,
   channels: Seq[Channel],
   versions: Seq[Version],
@@ -23,7 +23,7 @@ Versions page within Project overview.
 @projects.view(model, "#versions") {
 
     <script type="text/javascript" src="@routes.Assets.at("javascripts/versionList.js")"></script>
-    <script>
+    <script nonce="@nonce">
         PLUGIN_ID = '@model.pluginId';
         PROJECT_OWNER = '@model.ownerName';
         PROJECT_SLUG = '@model.slug';

--- a/app/views/projects/view.scala.html
+++ b/app/views/projects/view.scala.html
@@ -9,8 +9,8 @@ Base template for Project overview.
 @import ore.OreConfig
 @import ore.permission.EditSettings
 @import ore.project.FlagReasons
-@import views.html.helper.form
-@import views.html.helper.CSRF
+@import security.NonceFilter._
+@import views.html.helper.{CSRF, form}
 @(project: Project, active: String, noButtons: Boolean = false)(content: Html)(implicit messages: Messages,
         request: Request[_], flash: Flash, service: ModelService, config: OreConfig, users: UserBase)
 
@@ -100,7 +100,7 @@ Base template for Project overview.
                                     }
                                 }
                             </ul>
-                            <script>$(function() { $(".nav").find("@active").addClass("active"); });</script>
+                            <script nonce="@nonce">$(function() { $(".nav").find("@active").addClass("active"); });</script>
                         </div>
                     </div>
 
@@ -115,14 +115,14 @@ Base template for Project overview.
 
                             @if(hasUser) {
 
-                                <script>
+                                <script nonce="@nonce">
                                     var projectOwner = "@project.ownerName";
                                     var projectSlug = "@project.slug";
                                 </script>
 
                                 @defining(project.stars.contains(user)) { alreadyStarred =>
 
-                                    <script>var alreadyStarred = @alreadyStarred;</script>
+                                    <script nonce="@nonce">var alreadyStarred = @alreadyStarred;</script>
 
                                     @if(!isOwner(user)) {
                                         <button class="btn btn-default btn-star">

--- a/app/views/users/authors.scala.html
+++ b/app/views/users/authors.scala.html
@@ -3,6 +3,7 @@
 @import db.impl.access.{ProjectBase, UserBase}
 @import models.user.User
 @import ore.OreConfig
+@import security.NonceFilter._
 @import util.StringUtils._
 @(authors: Seq[User], ordering: String, page: Int)(implicit messages: Messages, request: Request[_],
         service: ModelService, config: OreConfig, users: UserBase, projectBase: ProjectBase)
@@ -19,7 +20,7 @@
 @bootstrap.layout("Authors - Ore") {
 
     <script type="text/javascript" src="@routes.Assets.at("javascripts/authors.js")"></script>
-    <script>CURRENT_PAGE = @page;</script>
+    <script nonce="@nonce">CURRENT_PAGE = @page;</script>
 
     <div class="container" style="margin-top: 90px">
         <div class="panel panel-default">

--- a/app/views/users/view.scala.html
+++ b/app/views/users/view.scala.html
@@ -5,9 +5,9 @@
 @import ore.OreConfig
 @import ore.permission.EditSettings
 @import ore.user.Prompts
+@import security.NonceFilter._
 @import util.StringUtils._
-@import views.html.helper.form
-@import views.html.helper.CSRF
+@import views.html.helper.{CSRF, form}
 @(user: User)(content: Html)(implicit messages: Messages, flash: Flash, request: Request[_], service: ModelService,
         config: OreConfig, users: UserBase)
 
@@ -34,14 +34,14 @@
 @bootstrap.layout(user.username) {
 
     <script type="text/javascript" src="@routes.Assets.at("javascripts/userPage.js")"></script>
-    <script>USERNAME = '@user.username';</script>
+    <script nonce="@nonce">USERNAME = '@user.username';</script>
 
     <div class="container" style="margin-top: 90px">
 
         @utils.alert("error")
 
         @flash.get("pgp-updated").map { updated =>
-          <script>
+          <script nonce="@nonce">
               $(function() {
                   $('#modal-pgp').modal('show');
               });

--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -30,6 +30,8 @@ play {
     http.session.maxAge                =   2419200 # 4 weeks
     http.parser.maxDiskBuffer          =   20MB
     ws.timeout.connection              =   10000
+
+    filters.headers.contentSecurityPolicy = "default-src 'self'; script-src 'self' '%NONCE-SOURCE%' https://www.google-analytics.com/analytics.js; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https:; font-src 'self' https://fonts.gstatic.com; block-all-mixed-content"
 }
 
 security {

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -73,9 +73,25 @@ function initTooltips() {
 
 /*
  * ==================================================
+ * =               Google Analytics                 =
+ * ==================================================
+ */
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-59476017-3', 'auto');
+ga('send', 'pageview');
+
+/*
+ * ==================================================
  * =                   Doc ready                    =
  * ==================================================
  */
+
+// Initialize highlighting
+hljs.initHighlightingOnLoad();
 
 $(function() {
     $('.alert-fade').fadeIn('slow');


### PR DESCRIPTION
Configures Play's [SecurityHeadersFilter](https://www.playframework.com/documentation/2.5.x/SecurityHeaders) to set some common HTTP headers:

```
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Permitted-Cross-Domain-Policies: master-only
```

CSP (`Content-Security-Policy`) is useful to prevent all kinds of XSS attacks, however it is a bit difficult to configure it for Ore: Ore uses a lot of inline scripts and inline styles and replacing all of them is out of scope for this PR (some of them can't be replaced easily). Consequently, it isn't too strict:

- Scripts are either loaded from JavaScript files hosted on Ore, or specified inside inline scripts with an explicit nonce (a random Base64 encoded string). A new nonce is generated for each request, so injecting a simple `<script>` tag isn't possible anymore.
- For CSS styles, `unsafe-inline` is allowed. Ore uses a lot of inline styles and these must be refactored into the separate CSS files before it can be made more strict.
- Images can be loaded from everywhere, but only using `https://`. I'm not entirely sure if images from `http://` are allowed currently. (All in all, mixed content is pretty bad though)

I don't have the discourse integration locally so I wasn't able to test the rules for that.

Fixes a part of #241