### PR TITLE
Fix category and sort filter overwriting each other

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -25,8 +25,8 @@ var KEY_MINUS = 173;
  * ==================================================
  */
 
-var CATEGORY_STRING = null;
-var SORT_STRING = null;
+var CATEGORY_STRING = CATEGORY_STRING || null;
+var SORT_STRING = SORT_STRING || null;
 var csrf = null;
 
 /*


### PR DESCRIPTION
Bug: When selecting a category the current sort option is reset, and when a sort is selected the category is reset.
This is caused by [home.js declaring the constants](https://github.com/SpongePowered/Ore/blob/cbb6217f30b720e02411ed4fbb426a2aaf80103d/public/javascripts/home.js#L26-L27) before main.js, therefore [main.js overwrites them](https://github.com/SpongePowered/Ore/blob/cbb6217f30b720e02411ed4fbb426a2aaf80103d/public/javascripts/main.js#L28-L29)