### PR TITLE
Disabled -> readonly to allow copy

### DIFF
--- a/app/views/projects/settings.scala.html
+++ b/app/views/projects/settings.scala.html
@@ -110,9 +110,9 @@
                                     <a href="#"><i class="fa fa-question-circle"></i></a>
                                 </p>
                                 @deploymentKey.map { key =>
-                                    <input class="form-control input-key" type="text" value="@key.value" disabled />
+                                    <input class="form-control input-key" type="text" value="@key.value" readonly />
                                 }.getOrElse {
-                                    <input class="form-control input-key" type="text" value="" disabled />
+                                    <input class="form-control input-key" type="text" value="" readonly />
                                 }
                             </div>
                             <div class="setting-content">


### PR DESCRIPTION
Disabled fields cannot have their contents copies out in some browsers. By making the field readonly instead, it becomes possible to copy the deployment key out.