### PR TITLE
Add a 404 error handler page

### DIFF
--- a/app/ErrorHandler.scala
+++ b/app/ErrorHandler.scala
@@ -38,4 +38,12 @@ class ErrorHandler @Inject()(env: Environment,
     }
   }
 
+  override def onNotFound(request: RequestHeader, message: String): Future[Result] = {
+    implicit val users: UserBase = service.getModelBase(classOf[UserBase])
+    implicit val projects: ProjectBase = service.getModelBase(classOf[ProjectBase])
+    implicit val session = request.session
+    implicit val impRequest = request
+    Future.successful(NotFound(views.html.errors.notFound()))
+  }
+
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -115,7 +115,7 @@ final class Application @Inject()(data: DataHelper,
   def setFlagResolved(flagId: Int, resolved: Boolean) = FlagAction { implicit request =>
     this.service.access[Flag](classOf[Flag]).get(flagId) match {
       case None =>
-        NotFound
+        notFound
       case Some(flag) =>
         flag.setResolved(resolved)
         Ok

--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -31,6 +31,8 @@ abstract class BaseController(implicit val env: OreEnv,
 
   override val signOns: ModelAccess[SignOn] = this.service.access[SignOn](classOf[SignOn])
 
+  override def notFound()(implicit request: Request[_]) = NotFound(views.html.errors.notFound())
+
   /**
     * Executes the given function with the specified result or returns a
     * NotFound if not found.
@@ -41,8 +43,8 @@ abstract class BaseController(implicit val env: OreEnv,
     * @param request  Incoming request
     * @return         NotFound or function result
     */
-  def withProject(author: String, slug: String)(fn: Project => Result)(implicit request: RequestHeader): Result
-  = this.projects.withSlug(author, slug).map(fn).getOrElse(NotFound)
+  def withProject(author: String, slug: String)(fn: Project => Result)(implicit request: Request[_]): Result
+  = this.projects.withSlug(author, slug).map(fn).getOrElse(notFound)
 
   /**
     * Executes the given function with the specified result or returns a
@@ -55,7 +57,7 @@ abstract class BaseController(implicit val env: OreEnv,
     * @return               NotFound or function result
     */
   def withVersion(versionString: String)(fn: Version => Result)
-                 (implicit request: RequestHeader, project: Project): Result
-  = project.versions.find(equalsIgnoreCase[VersionTable](_.versionString, versionString)).map(fn).getOrElse(NotFound)
+                 (implicit request: Request[_], project: Project): Result
+  = project.versions.find(equalsIgnoreCase[VersionTable](_.versionString, versionString)).map(fn).getOrElse(notFound)
 
 }

--- a/app/controllers/Organizations.scala
+++ b/app/controllers/Organizations.scala
@@ -89,7 +89,7 @@ class Organizations @Inject()(forms: OreForms,
     val user = request.user
     user.organizationRoles.get(id) match {
       case None =>
-        NotFound
+        notFound
       case Some(role) =>
         val dossier = role.organization.memberships
         status match {

--- a/app/controllers/Users.scala
+++ b/app/controllers/Users.scala
@@ -134,7 +134,7 @@ class Users @Inject()(fakeUser: FakeUser,
     } map {
       case (user, projectSeq) => Ok(views.users.projects(user, projectSeq, p))
     } getOrElse {
-      NotFound
+      notFound
     }
   }
 
@@ -271,7 +271,7 @@ class Users @Inject()(fakeUser: FakeUser,
   def markNotificationRead(id: Int) = Authenticated { implicit request =>
     request.user.notifications.get(id) match {
       case None =>
-        NotFound
+        notFound
       case Some(notification) =>
         notification.setRead(read = true)
         Ok

--- a/app/controllers/project/Channels.scala
+++ b/app/controllers/project/Channels.scala
@@ -105,7 +105,7 @@ class Channels @Inject()(forms: OreForms,
     } else {
       channels.find(c => c.name.equals(channelName)) match {
         case None =>
-          NotFound
+          notFound
         case Some(channel) =>
           if (channel.versions.nonEmpty && channels.count(c => c.versions.nonEmpty) == 1) {
             Redirect(self.showList(author, slug)).withError("error.channel.lastNonEmpty")

--- a/app/controllers/project/Pages.scala
+++ b/app/controllers/project/Pages.scala
@@ -44,7 +44,7 @@ class Pages @Inject()(forms: OreForms,
   def show(author: String, slug: String, page: String) = ProjectAction(author, slug) { implicit request =>
     val project = request.project
     project.pages.find(equalsIgnoreCase(_.name, page)) match {
-      case None => NotFound
+      case None => notFound
       case Some(p) => this.stats.projectViewed(implicit request => Ok(views.view(project, p)))
     }
   }

--- a/app/controllers/project/Projects.scala
+++ b/app/controllers/project/Projects.scala
@@ -168,7 +168,7 @@ class Projects @Inject()(stats: StatTracker,
     */
   def showProjectById(pluginId: String) = Action { implicit request =>
     this.projects.withPluginId(pluginId) match {
-      case None => NotFound
+      case None => notFound
       case Some(project) => Redirect(self.show(project.ownerName, project.slug))
     }
   }
@@ -232,7 +232,7 @@ class Projects @Inject()(stats: StatTracker,
     */
   def showIssues(author: String, slug: String) = ProjectAction(author, slug) { implicit request =>
     request.project.settings.issues match {
-      case None => NotFound
+      case None => notFound
       case Some(link) => Redirect(link)
     }
   }
@@ -246,7 +246,7 @@ class Projects @Inject()(stats: StatTracker,
     */
   def showSource(author: String, slug: String) = ProjectAction(author, slug) { implicit request =>
     request.project.settings.source match {
-      case None => NotFound
+      case None => notFound
       case Some(link) => Redirect(link)
     }
   }
@@ -263,7 +263,7 @@ class Projects @Inject()(stats: StatTracker,
     val project = request.project
     this.projects.fileManager.getIconPath(project) match {
       case None =>
-        project.owner.user.avatarUrl.map(Redirect(_)).getOrElse(NotFound)
+        project.owner.user.avatarUrl.map(Redirect(_)).getOrElse(notFound)
       case Some(iconPath) =>
         showImage(iconPath)
     }
@@ -341,7 +341,7 @@ class Projects @Inject()(stats: StatTracker,
     val user = request.user
     user.projectRoles.get(id) match {
       case None =>
-        NotFound
+        notFound
       case Some(role) =>
         val dossier = role.project.memberships
         status match {
@@ -420,7 +420,7 @@ class Projects @Inject()(stats: StatTracker,
   def showPendingIcon(author: String, slug: String) = ProjectAction(author, slug) { implicit request =>
     val project = request.project
     this.projects.fileManager.getPendingIconPath(project) match {
-      case None => NotFound
+      case None => notFound
       case Some(path) => showImage(path)
     }
   }

--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -25,7 +25,7 @@ import ore.{OreConfig, OreEnv, StatTracker}
 import play.api.Logger
 import play.api.i18n.MessagesApi
 import play.api.libs.json.Json
-import play.api.mvc.Result
+import play.api.mvc.{Result, Request}
 import play.filters.csrf.CSRF
 import security.spauth.SingleSignOnConsumer
 import util.StringUtils._
@@ -698,12 +698,12 @@ class Versions @Inject()(stats: StatTracker,
     sendSignatureFile(request.project.recommendedVersion)
   }
 
-  private def sendSignatureFile(version: Version): Result = {
+  private def sendSignatureFile(version: Version)(implicit request: Request[_]): Result = {
     val project = version.project
     val path = this.fileManager.getProjectDir(project.ownerName, project.name).resolve(version.signatureFileName)
     if (notExists(path)) {
       Logger.warn("project version missing signature file")
-      NotFound
+      notFound
     } else
       Ok.sendFile(path.toFile)
   }

--- a/app/controllers/sugar/Actions.scala
+++ b/app/controllers/sugar/Actions.scala
@@ -11,7 +11,7 @@ import models.project.Project
 import models.user.{SignOn, User}
 import ore.permission.scope.GlobalScope
 import ore.permission.{EditSettings, HideProjects, Permission}
-import play.api.mvc.Results.{NotFound, Redirect, Unauthorized}
+import play.api.mvc.Results.{Redirect, Unauthorized}
 import play.api.mvc._
 import security.spauth.SingleSignOnConsumer
 
@@ -202,6 +202,13 @@ trait Actions extends Calls with ActionHelpers {
     }
   }
 
+  /**
+   * Returns a NotFound result with the 404 HTML template.
+   *
+   * @return NotFound
+   */
+  def notFound()(implicit request: Request[_]): Result
+
   // Implementation
 
   private def userLock(redirect: Call) = new ActionFilter[AuthRequest] {
@@ -265,7 +272,7 @@ trait Actions extends Calls with ActionHelpers {
     project
       .flatMap(processProject(_, this.users.current(request)))
       .map(new ProjectRequest[A](_, request))
-      .toRight(NotFound)
+      .toRight(notFound()(request))
   }
 
   private def processProject(project: Project, user: Option[User]): Option[Project] = {
@@ -281,7 +288,7 @@ trait Actions extends Calls with ActionHelpers {
       Actions.this.projects.withSlug(author, slug)
         .flatMap(processProject(_, Some(request.user)))
         .map(new AuthedProjectRequest[A](_, request))
-        .toRight(NotFound)
+        .toRight(notFound()(request))
     }
   }
 
@@ -289,7 +296,7 @@ trait Actions extends Calls with ActionHelpers {
     def refine[A](request: Request[A]): Future[Either[Result, OrganizationRequest[A]]] = Future.successful {
       Actions.this.organizations.withName(organization)
         .map(new OrganizationRequest(_, request))
-        .toRight(NotFound)
+        .toRight(notFound()(request))
     }
   }
 
@@ -298,7 +305,7 @@ trait Actions extends Calls with ActionHelpers {
     def refine[A](request: AuthRequest[A]) = Future.successful {
       Actions.this.organizations.withName(organization)
         .map(new AuthedOrganizationRequest[A](_, request))
-        .toRight(NotFound)
+        .toRight(notFound()(request))
     }
   }
 

--- a/app/views/errors/notFound.scala.html
+++ b/app/views/errors/notFound.scala.html
@@ -1,0 +1,15 @@
+@import db.ModelService
+@import db.impl.access.UserBase
+@import ore.{OreConfig, OreEnv}
+@()(implicit messages: Messages, session: Session, requestHeader: RequestHeader, request: Request[_] = null,
+        service: ModelService, config: OreConfig, users: UserBase, env: OreEnv)
+
+@bootstrap.layout(messages("error.notFound.title"), user = false) {
+
+    <div class="container-error container">
+        <img src="@routes.Assets.at("images/ore-dark.png")" />
+        <h1 class="minor">@messages("error.notFound.title")</h1>
+        <h3 class="minor">@messages("error.notFound.message", requestHeader.uri)</h3>
+    </div>
+
+}

--- a/conf/messages
+++ b/conf/messages
@@ -97,6 +97,8 @@ error.offline                   =   Offline
 error.offline.title             =   You are offline and this site is not cached.
 error.offline.body              =   Most likely your internet connection is currently not available and we also do not have this page cached on your device. You should still be able to see the a cached version of most pages. This page will be available again when there is a internet connection.
 error.offline.alert             =   You are currently offline, so the data you are seeing may be out of date and you can not update anything.
+error.notFound.title            =   404 Not Found
+error.notFound.message          =   The URI "{0}" could not be found
 
 error.plugin.fileExtension      =   Plugin file must be either a JAR or ZIP file.
 error.plugin.sig.fileExtension  =   Signature file must be either a SIG or ASC file.


### PR DESCRIPTION
Looks like this:

![404 page](https://puu.sh/v47qZ/0798203297.png)

There is a minor issue when the page is shown after falling back to the [`ErrorHandler`](https://github.com/simon816/Ore/blob/bec33404f98228dae6c7c2b1c6a7badcd9e33ff6/app/ErrorHandler.scala#L41-L47) , the `Request[_]` implicit variable for [`layout.scala.html`](https://github.com/SpongePowered/Ore/blob/master/app/views/bootstrap/layout.scala.html#L11) is null because we are only given a `RequestHeader` variable. This causes the [CSRF token](https://github.com/SpongePowered/Ore/blob/master/app/views/bootstrap/layout.scala.html#L67-L69) and the [nonce](https://github.com/SpongePowered/Ore/blob/master/app/security/NonceFilter.scala#L15-L19) values to not exist on the page.
The fix would be to make all `Request[_]` parameters into `RequestHeader`, but I didn't want to be too disruptive.