### PR TITLE
Add warning for external links on pages. Closes #218

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -84,6 +84,16 @@ final class Application @Inject()(data: DataHelper,
   }
 
   /**
+    * Show external link warning page.
+    *
+    * @return External link page
+    */
+  def linkOut(remoteUrl: String) = {
+    Action { implicit request =>
+      Ok(views.linkout(remoteUrl))
+    }
+  }
+  /**
     * Shows the moderation queue for unreviewed versions.
     *
     * @return View of unreviewed versions.

--- a/app/views/linkout.scala.html
+++ b/app/views/linkout.scala.html
@@ -1,0 +1,34 @@
+@import db.ModelService
+@import db.impl.access.UserBase
+@import ore.{OreConfig, OreEnv}
+@(remoteUrl: String)(implicit messages: Messages, session: Session, requestHeader: RequestHeader, request: Request[_] = null,
+        service: ModelService, config: OreConfig, users: UserBase, env: OreEnv)
+
+@bootstrap.layout(messages("general.linkout.title")) {
+
+    <div class="container" style="margin-top: 90px;">
+        <div class="row">
+            <div class="col-md-6 col-md-offset-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+	                    <h3 class="panel-title">
+	                        @messages("general.linkout.title")
+	                    </h3>
+                    </div>
+                    <div class="panel-body">
+                        <p>@messages("general.linkout.warning", remoteUrl)</p>
+                        <a href="/" class="pull-left unsafe-dl-back">
+                            <i class="fa fa-arrow-left"></i> @messages("project.back")
+                        </a>
+                        <a href="@remoteUrl">
+	                        <button class="pull-right btn btn-primary">
+	                            @messages("general.continue")
+	                        </button>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+}

--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -9,6 +9,7 @@ application {
     db.default-timeout  =   10
     uploadsDir = "uploads"
     uploadsDir = ${?UPLOADS_DIR}
+    trustedUrlHost      =   "spongepowered.org"
     
     fakeUser {
         enabled    =   false

--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -9,7 +9,7 @@ application {
     db.default-timeout  =   10
     uploadsDir = "uploads"
     uploadsDir = ${?UPLOADS_DIR}
-    trustedUrlHost      =   "spongepowered.org"
+    trustedUrlHosts     =   [ ".spongepowered.org" ]
     
     fakeUser {
         enabled    =   false

--- a/conf/messages
+++ b/conf/messages
@@ -55,6 +55,8 @@ general.forgeMod.tooltip        =   To mark your project as a Forge mod, add for
 general.any                     =   Any
 general.platform                =   Platform
 general.notice                  =   Notice
+general.linkout.title           =   External Link Warning
+general.linkout.warning         =   You have clicked on an external link to "{0}". If you did not intend to visit this link, please go back. Otherwise, click continue.
 
 admin.health.title = Ore Health Report
 admin.health.discuss = Missing discussion topic

--- a/conf/routes
+++ b/conf/routes
@@ -55,6 +55,7 @@ GET     /api/:version/users/:user                                   @controllers
 # ---------- Application ----------
 
 GET     /                                                           @controllers.Application.showHome(categories: Option[String], q: Option[String], sort: Option[Int], page: Option[Int], platform: Option[String])
+GET     /linkout                                                    @controllers.Application.linkOut(remoteUrl: String)
 GET     /signup                                                     @controllers.Users.signUp()
 GET     /login                                                      @controllers.Users.logIn(sso: Option[String], sig: Option[String], returnUrl: Option[String])
 GET     /logout                                                     @controllers.Users.logOut(returnUrl: Option[String])


### PR DESCRIPTION
Closes #218

![image](https://user-images.githubusercontent.com/1497508/28221779-954d083e-68bc-11e7-8f64-f43ed17144a5.png)

Design based on the warning for un-reviewed plugin files.


Set the `app.trustedUrlHost` config option to the trusted host


The "get me out of here" link simply goes to the homepage, maybe it could go to the `Referer` header if exists or "javascript:history.go(-1)"?