### PR TITLE
Don't clobber CSRF token when modal opens, fixes #269

### DIFF
--- a/public/javascripts/memberList.js
+++ b/public/javascripts/memberList.js
@@ -65,7 +65,7 @@ function initMember(memberRow) {
     // Set form input on modal when delete is clicked
     memberRow.find('.fa-trash').parent().click(function(event) {
         event.preventDefault();
-        $('#modal-user-delete').find('input').val(getItemContainer($(this)).find('.username').text());
+        $('#modal-user-delete').find('input[name=username]').val(getItemContainer($(this)).find('.username').text().trim());
     });
 }
 


### PR DESCRIPTION
JS matched too many inputs and made the CSRF token set to the username.

This PR also trims the value to remove extraneous spacing.