### PR TITLE
Add Downloads Counter for the Versions Page (Fixes #268)

### DIFF
--- a/app/views/projects/versions/list.scala.html
+++ b/app/views/projects/versions/list.scala.html
@@ -90,6 +90,7 @@ Versions page within Project overview.
                                                     <div class="pull-right">
                                                         <span class="date">@prettifyDate(version.createdAt.get)</span>
                                                         <span class="date">@version.humanFileSize</span>
+                                                        <span class="date">@version.downloadCount Downloads</span>
                                                         <a href="@versionRoutes.download(
                                                             model.ownerName, model.slug, version.versionString, None)">
                                                             <i title="Download" class="fa fa-download"></i>

--- a/app/views/projects/versions/list.scala.html
+++ b/app/views/projects/versions/list.scala.html
@@ -89,8 +89,12 @@ Versions page within Project overview.
                                                 <td>
                                                     <div class="pull-right">
                                                         <span class="date">@prettifyDate(version.createdAt.get)</span>
+                                                        @defining(version.downloadCount) { d: Int =>
+                                                            <span class="date">
+                                                                @d Download@if(d != 1) { s } else { &nbsp; }
+                                                            </span>
+                                                        }
                                                         <span class="date">@version.humanFileSize</span>
-                                                        <span class="date">@version.downloadCount Downloads</span>
                                                         <a href="@versionRoutes.download(
                                                             model.ownerName, model.slug, version.versionString, None)">
                                                             <i title="Download" class="fa fa-download"></i>


### PR DESCRIPTION
Versions now show how many downloads they have. I wasn't able to test this super thoroughly locally, but digging through the code suggests that this should work completely fine.