### PR TITLE
Show who Signed a Plugin in the Versions List (Closes #300)

### DIFF
--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -198,8 +198,10 @@ class Versions @Inject()(stats: StatTracker,
             try {
               this.factory.processSubsequentPluginUpload(uploadData, user, request.project).fold(
                 err => Redirect(call).withError(err),
-                version =>
+                version => {
+                  version.underlying.authorId = user.id.getOrElse(-1)
                   Redirect(self.showCreatorWithMeta(request.project.ownerName, slug, version.underlying.versionString))
+                }
               )
             } catch {
               case e: InvalidPluginFileException =>

--- a/app/db/impl/schema.scala
+++ b/app/db/impl/schema.scala
@@ -154,6 +154,7 @@ class VersionTable(tag: Tag) extends ModelTable[Version](tag, "project_versions"
   def channelId         =   column[Int]("channel_id")
   def fileSize          =   column[Long]("file_size")
   def hash              =   column[String]("hash")
+  def authorId          =   column[Int]("author_id")
   def isReviewed        =   column[Boolean]("is_reviewed")
   def reviewerId        =   column[Int]("reviewer_id")
   def approvedAt        =   column[Timestamp]("approved_at")
@@ -161,7 +162,7 @@ class VersionTable(tag: Tag) extends ModelTable[Version](tag, "project_versions"
   def signatureFileName =   column[String]("signature_file_name")
 
   override def * = (id.?, createdAt.?, projectId, versionString, dependencies, assets.?, channelId,
-                    fileSize, hash, description.?, downloads, isReviewed, reviewerId, approvedAt.?, fileName,
+                    fileSize, hash, authorId, description.?, downloads, isReviewed, reviewerId, approvedAt.?, fileName,
                     signatureFileName) <> ((Version.apply _).tupled, Version.unapply)
 }
 

--- a/app/db/impl/table/ModelKeys.scala
+++ b/app/db/impl/table/ModelKeys.scala
@@ -68,6 +68,7 @@ object ModelKeys {
 
   // Version
   val IsReviewed            =   new BooleanKey[Version](_.isReviewed, _.isReviewed)
+  val AuthorId              =   new IntKey[Version](_.authorId, _.authorId)
   val ReviewerId            =   new IntKey[Version](_.reviewerId, _.reviewerId)
   val ApprovedAt            =   new TimestampKey[Version](_.approvedAt, _.approvedAt.orNull)
   val ChannelId             =   new IntKey[Version](_.channelId, _.channelId)

--- a/app/models/project/Version.scala
+++ b/app/models/project/Version.scala
@@ -41,6 +41,7 @@ case class Version(override val id: Option[Int] = None,
                    channelId: Int = -1,
                    fileSize: Long,
                    hash: String,
+                   private var _authorId: Int = -1,
                    private var _description: Option[String] = None,
                    private var _downloads: Int = 0,
                    private var _isReviewed: Boolean = false,
@@ -133,6 +134,18 @@ case class Version(override val id: Option[Int] = None,
   def setReviewed(reviewed: Boolean) = {
     this._isReviewed = reviewed
     if (isDefined) update(IsReviewed)
+  }
+
+  def authorId: Int = this._authorId
+
+  def author: Option[User] = this.userBase.get(this._authorId)
+
+  def authorId_=(authorId: Int) = {
+    this._authorId = authorId
+    // If the project is in the Database
+    if (isDefined) {
+      update(AuthorId)
+    }
   }
 
   def reviewerId: Int = this._reviewerId
@@ -232,6 +245,7 @@ object Version {
     private var _dependencyIds: List[String] = List()
     private var _description: String = _
     private var _projectId: Int = -1
+    private var _authorId: Int = -1
     private var _fileSize: Long = -1
     private var _hash: String = _
     private var _fileName: String = _
@@ -267,6 +281,11 @@ object Version {
       this
     }
 
+    def authorId(authorId: Int) = {
+      this._authorId = authorId
+      this
+    }
+
     def fileName(fileName: String) = {
       this._fileName = fileName
       this
@@ -286,6 +305,7 @@ object Version {
         projectId = this._projectId,
         fileSize = this._fileSize,
         hash = checkNotNull(this._hash, "hash null", ""),
+        _authorId = checkNotNull(this._authorId, "author id null", ""),
         fileName = checkNotNull(this._fileName, "file name null", ""),
         signatureFileName = checkNotNull(this._signatureFileName, "signature file name null", "")))
     }

--- a/app/ore/project/factory/ProjectFactory.scala
+++ b/app/ore/project/factory/ProjectFactory.scala
@@ -324,6 +324,7 @@ trait ProjectFactory {
       channelId = channel.id.get,
       fileSize = pendingVersion.fileSize,
       hash = pendingVersion.hash,
+      _authorId = pendingVersion.authorId,
       fileName = pendingVersion.fileName,
       signatureFileName = pendingVersion.signatureFileName
     ))

--- a/app/util/DataHelper.scala
+++ b/app/util/DataHelper.scala
@@ -88,6 +88,7 @@ final class DataHelper @Inject()(config: OreConfig,
               channelId = channel.id.get,
               fileSize = 1,
               hash = "none",
+              _authorId = i,
               fileName = "none",
               signatureFileName = "none"))
             if (l == 0)

--- a/app/views/projects/versions/create.scala.html
+++ b/app/views/projects/versions/create.scala.html
@@ -1,7 +1,7 @@
 @import controllers.project.{routes => projectRoutes}
 @import db.ModelService
 @import db.impl.access.UserBase
-@import models.project.{Channel, Project}
+@import models.project.{Channel, Project, Version}
 @import ore.OreConfig
 @import ore.project.factory.PendingVersion
 @import security.NonceFilter._
@@ -41,7 +41,7 @@
 
                         @if(pending.isDefined) {
                             @* Show plugin meta *@
-                            @defining(pending.get.underlying) { version =>
+                            @defining(pending.get.underlying) { version: Version =>
                                 <div class="plugin-meta">
                                     <table class="plugin-meta-table">
                                         <tr>
@@ -158,7 +158,7 @@
 
                         @if(pending.isDefined) {
                             @* Ready to go! *@
-                            @defining(pending.get.underlying) { version =>
+                            @defining(pending.get.underlying) { version: Version =>
                                 @form(action = projectRoutes.Versions.publish(
                                     project.ownerName, project.slug, version.versionString),
                                     'id -> "form-publish", 'class -> "pull-right") {

--- a/app/views/projects/versions/list.scala.html
+++ b/app/views/projects/versions/list.scala.html
@@ -10,6 +10,7 @@ Versions page within Project overview.
 @import models.project.Project
 @import models.project.Channel
 @import models.project.Version
+@import models.user.User
 @(model: Project,
   channels: Seq[Channel],
   versions: Seq[Version],
@@ -91,8 +92,15 @@ Versions page within Project overview.
                                                         <span class="date">@prettifyDate(version.createdAt.get)</span>
                                                         @defining(version.downloadCount) { d: Int =>
                                                             <span class="date">
-                                                                @d Download@if(d != 1) { s } else { &nbsp; }
+                                                                @d Download@if(d != 1) {s}
                                                             </span>
+                                                        }
+                                                        @if(version.authorId != -1) {
+                                                            @defining(version.author.get.name) { author: String =>
+                                                                <a class="date" href="@routes.Users.showProjects(author, None)">
+                                                                    <i title="Signed By: @author" class="fa fa-key"></i>
+                                                                </a>
+                                                            }
                                                         }
                                                         <span class="date">@version.humanFileSize</span>
                                                         <a href="@versionRoutes.download(

--- a/conf/evolutions/default/79.sql
+++ b/conf/evolutions/default/79.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+alter table project_versions add column author_id bigint default -1;
+
+# --- !Downs
+
+alter table project_versions drop column author_id;


### PR DESCRIPTION
Since Projects can have multiple authors, I've added an authorId field
to Versions (and updated the DB). When someone publishes a Version,
they are assigned as the author.

A key appears in the Versions list next to Versions that have a proper
`authorId`. If they don't have an `authorId` (like all the ones currently
in the DB), there won't be a key. The key links to author's page.

Closes #300