### PR TITLE
Fix & Clean up Organization Membership Modifications (Fixes #301)

### DIFF
--- a/app/form/organization/OrganizationMembersUpdate.scala
+++ b/app/form/organization/OrganizationMembersUpdate.scala
@@ -41,7 +41,7 @@ case class OrganizationMembersUpdate(override val users: List[Int],
     // Update existing roles
     val orgRoleTypes = RoleTypes.values.filter(_.roleClass.equals(classOf[OrganizationRole]))
     for ((user, i) <- this.userUps.zipWithIndex) {
-      organization.memberships.members.find(_.username.equalsIgnoreCase(user)).foreach { user =>
+      organization.memberships.members.find(_.username.equalsIgnoreCase(user.trim)).foreach { user =>
         user.headRole.roleType = orgRoleTypes.find(_.title.equals(roleUps(i)))
           .getOrElse(throw new RuntimeException("supplied invalid role type"))
       }

--- a/app/views/users/invite/userSearch.scala.html
+++ b/app/views/users/invite/userSearch.scala.html
@@ -1,7 +1,7 @@
-@()
+@()(implicit messages: Messages)
 
 <div class="input-group input-group-sm user-search">
-    <input type="text" class="form-control" placeholder="Find user&hellip;" />
+    <input type="text" class="form-control" placeholder="@messages("org.users.add")&hellip;" />
     <span class="input-group-btn">
         <button disabled class="btn btn-default btn-search"><i class="fa fa-search"></i></button>
     </span>

--- a/app/views/users/memberList.scala.html
+++ b/app/views/users/memberList.scala.html
@@ -60,7 +60,8 @@
                                 aria-label="@messages("general.close")">
                             <span aria-hidden="true">&times;</span>
                         </button>
-                        <h4 class="modal-title" id="label-user-delete">@messages("project.removeMember")</h4>
+                        <h4 class="modal-title" id="label-use
+                        r-delete">@messages("project.removeMember")</h4>
                     </div>
                     <div class="modal-body">@messages("project.removeMember.confirm")</div>
                     <div class="modal-footer">
@@ -95,7 +96,7 @@
                         @form(action = saveCall, 'id -> "save") {
                             @CSRF.formField
                             <button class="btn-members-save btn btn-default btn-panel btn-xs" data-toggle="tooltip"
-                                    data-placement="top" data-title="Send updates" style="display: none;">
+                                    data-placement="top" data-title="@messages("org.users.save")" style="display: none;">
                                 <i class="fa fa-paper-plane"></i>
                             </button>
                         }
@@ -118,9 +119,9 @@
 
                         @if(canEdit && !member.headRole.roleType.trust.equals(Absolute)) {
                             <a href="#">
-                                <i class="fa fa-trash" data-toggle="modal" data-target="#modal-user-delete"></i>
+                                <i style="padding-left:5px" class="fa fa-trash" data-toggle="modal" data-target="#modal-user-delete"></i>
                             </a>
-                            <a href="#"><i class="fa fa-edit"></i></a>
+                            <a href="#"><i style="padding-left:5px" class="fa fa-edit"></i></a>
                         }
 
                         <span class="minor pull-right">

--- a/app/views/users/memberList.scala.html
+++ b/app/views/users/memberList.scala.html
@@ -60,8 +60,7 @@
                                 aria-label="@messages("general.close")">
                             <span aria-hidden="true">&times;</span>
                         </button>
-                        <h4 class="modal-title" id="label-use
-                        r-delete">@messages("project.removeMember")</h4>
+                        <h4 class="modal-title" id="label-user-delete">@messages("project.removeMember")</h4>
                     </div>
                     <div class="modal-body">@messages("project.removeMember.confirm")</div>
                     <div class="modal-footer">
@@ -116,7 +115,11 @@
                         <a class="username" href="@routes.Users.showProjects(member.username, None)">
                             @member.username
                         </a>
-
+                        @defining(member.headRole.id) { id: Option[Int] =>
+                            @if(id.isDefined) {
+                                <p style="display: none;" class="role-id">@id.get</p>
+                            }
+                        }
                         @if(canEdit && !member.headRole.roleType.trust.equals(Absolute)) {
                             <a href="#">
                                 <i style="padding-left:5px" class="fa fa-trash" data-toggle="modal" data-target="#modal-user-delete"></i>

--- a/app/views/users/memberList.scala.html
+++ b/app/views/users/memberList.scala.html
@@ -126,7 +126,7 @@
 
                         <span class="minor pull-right">
                             @if(!member.headRole.isAccepted) {
-                                <span class="minor">(Invited)</span>
+                                <span class="minor">(Invited as @member.headRole.roleType.title)</span>
                             } else {
                                 @member.headRole.roleType.title
                             }

--- a/app/views/users/view.scala.html
+++ b/app/views/users/view.scala.html
@@ -254,7 +254,9 @@
     </div>
 
     @utils.modal("modal-pgp-show", "label-pgp-show", "user.pgp.pubKey") {
-        <pre style="text-align:center">@user.pgpPubKey.get</pre>
+        @if(user.pgpPubKey.isDefined) {
+            <pre style="text-align: center">@user.pgpPubKey.get</pre>
+        }
     }
 
     @utils.modal("modal-lock", "label-lock", if (user.isLocked) "user.unlock" else "user.lock") {

--- a/conf/messages
+++ b/conf/messages
@@ -190,6 +190,8 @@ org.info            =   Organizations allow you group users provide closer colla
 org.name            =   Organization name
 org.welcome         =   Welcome to your new organization! Start by changing your avatar by clicking on it.
 org.welcome.confirm =   Got it!
+org.users.add       =   Add User
+org.users.save      =   Save Users
 
 version                         =   Version
 version.description             =   Description

--- a/public/javascripts/memberList.js
+++ b/public/javascripts/memberList.js
@@ -52,9 +52,12 @@ function initMember(memberRow) {
         var container = getItemContainer($(this)).addClass('user-changed');
         var input = $('#select-role').clone().removeAttr('id').attr('form', 'save');
 
+        var roleId = container.find('.role-id').text();
+        input.find('option:eq(' + roleId + ')').attr('selected', '');
+
         // Add input
         container.find('span').replaceWith(input.show());
-        var username = container.find('.username').text();
+        var username = container.find('.username').text().trim();
         container.append('<input type="hidden" form="save" value="' + username + '" />');
 
         // Remove edit button and update input names


### PR DESCRIPTION
There was some whitespace being passed into an equals check, causing
it to fail.

Members that have been invited will now display what role they will be,
and that role is editable.

An NPE with Org PGP Keys was fixed by checking to see if it exists
before using it.

The modification icons were spaced out and the text was extracted into `conf/messages`
It looks a lot better now.

Fixes #301