### PR TITLE
Fix files being placed in the incorrect plugin folder (Fixes #258)

### DIFF
--- a/app/ore/project/factory/ProjectFactory.scala
+++ b/app/ore/project/factory/ProjectFactory.scala
@@ -344,7 +344,7 @@ trait ProjectFactory {
     val oldPath = plugin.path
     val oldSigPath = plugin.signaturePath
 
-    val projectDir = this.fileManager.getProjectDir(project.ownerName, meta.getName)
+    val projectDir = this.fileManager.getProjectDir(project.ownerName, project.name)
     val newPath = projectDir.resolve(oldPath.getFileName)
     val newSigPath = projectDir.resolve(oldSigPath.getFileName)
 

--- a/app/util/FileUtils.scala
+++ b/app/util/FileUtils.scala
@@ -47,12 +47,16 @@ object FileUtils {
   private class DeleteFileVisitor extends SimpleFileVisitor[Path] {
 
     override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-      Files.delete(file)
+      if (Files.exists(file)) {
+        Files.delete(file)
+      }
       FileVisitResult.CONTINUE
     }
 
     override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
-      Files.delete(dir)
+      if (Files.exists(dir)) {
+        Files.delete(dir)
+      }
       FileVisitResult.CONTINUE
     }
 


### PR DESCRIPTION
Instead of using the plugin's name for the folder, we want to use
the project's name because the project's name can change.

I also added some guards for the DeleteFileVisitor because it was
throwing errors for files that didn't exist.

Fixes #258