### PR TITLE
Display all members if the user is allowed to edit roles (Fixes #312)

### DIFF
--- a/app/views/users/memberList.scala.html
+++ b/app/views/users/memberList.scala.html
@@ -17,8 +17,8 @@
 
 @shouldShowMember(member: Member[_ <: RoleModel]) = @{
     val headRole = member.headRole
-    headRole.isVisible && (headRole.isAccepted ||
-            (userBase.current.isDefined && userBase.current.get.username.equals(model.owner.user.name)))
+    val isCurrentUsersProject = userBase.current.isDefined && userBase.current.get.username.equals(model.owner.user.name)
+    canEdit || (headRole.isVisible && (headRole.isAccepted || isCurrentUsersProject))
 }
 
 @roleClass = @{


### PR DESCRIPTION
If the user can edit the roles of a project, they should be allowed to
see all the members.

![fix](https://i.imgur.com/7YlzNFd.png)

Fixes #312