### PR TITLE
Order Projects on User Pages by Stars and Name

### DIFF
--- a/app/controllers/Users.scala
+++ b/app/controllers/Users.scala
@@ -126,8 +126,8 @@ class Users @Inject()(fakeUser: FakeUser,
     val p = page.getOrElse(1)
     val offset = (p - 1) * pageSize
     this.users.withName(username).map { u =>
-      (u, u.projects.sorted(
-        ordering = _.stars.desc,
+      (u, u.projects.sortedMultipleOrders(
+        orderings = p => List(p.stars.desc, p.name.asc),
         filter = _.recommendedVersionId =!= -1,
         limit = pageSize,
         offset = offset))

--- a/app/db/access/ModelAccess.scala
+++ b/app/db/access/ModelAccess.scala
@@ -121,6 +121,13 @@ class ModelAccess[M <: Model](val service: ModelService,
   = await(this.service.sorted[M](this.modelClass, ordering, (this.baseFilter && filter).fn, limit, offset)).get
 
   /**
+    * Same as sorted but with multiple orderings
+    */
+  def sortedMultipleOrders(orderings: M#T => List[ColumnOrdered[_]], filter: M#T => Rep[Boolean] = null, limit: Int = -1,
+             offset: Int = -1): Seq[M]
+  = await(this.service.sortedMultipleOrders[M](this.modelClass, orderings, (this.baseFilter && filter).fn, limit, offset)).get
+
+  /**
     * Filters this set by the given function.
     *
     * @param filter Filter to use


### PR DESCRIPTION
Projects need to be sorted by their names since they could have the
same star count.

collectMultipleSorts copies Query#sortBy but it supports a List of
ColumnOrdereds. The implementation in Slick only supports one or
Tuples.

Fixes #286