### PR TITLE
Check Org Permissions When Viewing a Project in an Org

### DIFF
--- a/app/ore/permission/Permission.scala
+++ b/app/ore/permission/Permission.scala
@@ -20,4 +20,4 @@ case object SeedOre             extends Permission { val trust = Absolute }
 case object MigrateOre          extends Permission { val trust = Absolute }
 case object CreateProject       extends Permission { val trust = Absolute }
 case object PostAsOrganization  extends Permission { val trust = Standard }
-case object EditApiKeys       extends Permission { val trust = Absolute }
+case object EditApiKeys         extends Permission { val trust = Absolute }

--- a/app/ore/permission/PermissionPredicate.scala
+++ b/app/ore/permission/PermissionPredicate.scala
@@ -1,6 +1,8 @@
 package ore.permission
 
-import models.user.User
+import db.impl.access.OrganizationBase
+import models.project.Project
+import models.user.{Organization, User}
 import ore.permission.scope.ScopeSubject
 
 /**
@@ -14,6 +16,21 @@ case class PermissionPredicate(user: User, not: Boolean = false) {
 
   protected case class AndThen(user: User, p: Permission, not: Boolean) {
     def in(subject: ScopeSubject): Boolean = {
+      // Test org perms on projects
+      subject match {
+        case project: Project =>
+          val id = project.ownerId
+          val maybeOrg: Option[Organization] = project.service.getModelBase(classOf[OrganizationBase]).get(id)
+          if (maybeOrg.isDefined) {
+            // Project's owner is an organization
+            val org = maybeOrg.get
+            // Test the org scope and the project scope
+            val orgTest = org.scope.test(user, p)
+            val projectTest = project.scope.test(user, p)
+            return orgTest | projectTest
+          }
+        case _ =>
+      }
       val result = subject.scope.test(user, p)
       if (not) !result else result
     }

--- a/app/util/FileUtils.scala
+++ b/app/util/FileUtils.scala
@@ -7,6 +7,8 @@ import java.nio.file.attribute.BasicFileAttributes
 
 object FileUtils {
 
+  val Logger = play.api.Logger("FileUtils")
+
   /**
     * Formats the number of bytes into a human readable file size
     * (e.g. 100.0 KB).
@@ -28,7 +30,11 @@ object FileUtils {
     * @param dir The directory to delete
     */
   def deleteDirectory(dir: Path): Unit = {
-    Files.walkFileTree(dir, DeleteFileVisitor)
+    if (Files.exists(dir)) {
+      Files.walkFileTree(dir, DeleteFileVisitor)
+    } else {
+      Logger.info(s"Tried to remove directory that doesn't exist: $dir")
+    }
   }
 
   /**
@@ -37,7 +43,11 @@ object FileUtils {
     * @param dir The directory to clean
     */
   def cleanDirectory(dir: Path): Unit = {
-    Files.walkFileTree(dir, new CleanFileVisitor(dir))
+    if (Files.exists(dir)) {
+      Files.walkFileTree(dir, new CleanFileVisitor(dir))
+    } else {
+      Logger.info(s"Tried to remove directory that doesn't exist: $dir")
+    }
   }
 
   /**
@@ -49,6 +59,8 @@ object FileUtils {
     override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
       if (Files.exists(file)) {
         Files.delete(file)
+      } else {
+        Logger.info(s"Tried to remove file that doesn't exist: $file")
       }
       FileVisitResult.CONTINUE
     }
@@ -56,6 +68,8 @@ object FileUtils {
     override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
       if (Files.exists(dir)) {
         Files.delete(dir)
+      } else {
+        Logger.info(s"Tried to remove directory that doesn't exist: $dir")
       }
       FileVisitResult.CONTINUE
     }


### PR DESCRIPTION
When viewing a Project, we need to check if the permission is allowed
in the OrganizationScope.

I also added a logger that logs when absent files try to be deleted too.

Fixes #285