### PR TITLE
WIP: Add docker-compose setup #309

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,33 @@ development environment, most of the defaults will do except you must set `appli
 authentication to the Sponge forums. In addition, the SSL certification authority of https://forums.spongepowered.org is
 not typically recognized by the JVM so you will either have to manually add the cert to your JVM or set 
 `discourse.api.enabled` to `false` in the configuration file.
+
+
+## Docker Compose Testing Environment
+
+You'll need:
+
+* A working Docker install (for Linux, install from your package manager; for macOS, use [Docker for Mac](https://docs.docker.com/docker-for-mac/install/); for Windows, use [Docker for Windows](https://docs.docker.com/docker-for-windows/install/))
+* docker-compose (for Linux, install from your package manager; for macOS/Windows, these should be included with Docker for Mac/Windows)
+
+Run
+
+```
+docker-compose up -d
+```
+
+and wait for a bit. When you see
+
+```
+su -c '/env/bin/python spongeauth/manage.py runserver 0.0.0.0:8000' spongeauth
+```
+
+then you should be able to visit http://localhost:8000 and have a working SpongeAuth install.
+
+If you need an administrator account for spongeauth, you should be able to run:
+
+```
+docker-compose run spongeauth /env/bin/python spongeauth/manage.py createsuperuser
+```
+
+and follow the prompts to get an administrator account. This must be done after the `up` command above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "2"
+
+volumes:
+  spongeauth-db:
+
+services:
+  db:
+    image: postgres:9.6
+    volumes:
+      - spongeauth-db:/var/lib/postgresql
+    environment:
+      POSTGRES_USER: spongeauth
+      POSTGRES_PASSWORD: spongeauth
+      POSTGRES_DB: spongeauth
+  mail:
+    image: mailhog/mailhog:latest
+    ports:
+      - "8025:8025"
+  spongeauth:
+    image: spongepowered/spongeauth:latest
+    ports:
+      - "8000:8000"
+    links:
+      - "db"
+      - "mail"


### PR DESCRIPTION
This is a WIP local setup for use in easing the complexity of setting up ore.
It currently only has a functioning spongeauth setup. I will be working on adding another db to the postgres instance to handle ore, adding instructions for hooking ore into this, and then getting a local discourse linked as well.

Scripts for generating fake accounts, api keys, etc. will be worked on as well