### PR TITLE
Fix version & channel deletion

### DIFF
--- a/app/db/impl/access/ProjectBase.scala
+++ b/app/db/impl/access/ProjectBase.scala
@@ -151,7 +151,7 @@ class ProjectBase(override val service: ModelService,
 
     channel.versions.all.foreach { version: Version =>
       val versionFolder = this.fileManager.getVersionDir(project.ownerName, project.name, version.name)
-      Files.deleteIfExists(versionFolder)
+      FileUtils.deleteDirectory(versionFolder)
       version.remove()
     }
   }
@@ -181,7 +181,7 @@ class ProjectBase(override val service: ModelService,
       this.deleteChannel(channel)
 
     val versionDir = this.fileManager.getVersionDir(proj.ownerName, project.name, version.name)
-    Files.deleteIfExists(versionDir)
+    FileUtils.deleteDirectory(versionDir)
   }
 
   /**


### PR DESCRIPTION
[Files.deleteIfExists](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path)) will throw a `DirectoryNotEmptyException` if the
directory it is trying to delete is not empty. FileUtils has a function
to delete directories that we can use.

Closes #361