### PR TITLE
Give Organization Admins their own Trust Level

### DIFF
--- a/app/ore/permission/Permission.scala
+++ b/app/ore/permission/Permission.scala
@@ -1,6 +1,6 @@
 package ore.permission
 
-import ore.permission.role.{Absolute, Limited, Standard, Trust}
+import ore.permission.role._
 
 /**
   * Represents a permission for a user to do something in the application.
@@ -8,7 +8,7 @@ import ore.permission.role.{Absolute, Limited, Standard, Trust}
 sealed trait Permission { def trust: Trust }
 case object EditChannels        extends Permission { val trust = Standard }
 case object EditPages           extends Permission { val trust = Limited  }
-case object EditSettings        extends Permission { val trust = Absolute }
+case object EditSettings        extends Permission { val trust = Lifted   }
 case object EditVersions        extends Permission { val trust = Standard }
 case object HideProjects        extends Permission { val trust = Standard }
 case object ReviewFlags         extends Permission { val trust = Standard }
@@ -18,6 +18,6 @@ case object ViewLogs            extends Permission { val trust = Standard }
 case object ResetOre            extends Permission { val trust = Absolute }
 case object SeedOre             extends Permission { val trust = Absolute }
 case object MigrateOre          extends Permission { val trust = Absolute }
-case object CreateProject       extends Permission { val trust = Absolute }
+case object CreateProject       extends Permission { val trust = Lifted   }
 case object PostAsOrganization  extends Permission { val trust = Standard }
-case object EditApiKeys         extends Permission { val trust = Absolute }
+case object EditApiKeys         extends Permission { val trust = Lifted   }

--- a/app/ore/permission/role/RoleTypes.scala
+++ b/app/ore/permission/role/RoleTypes.scala
@@ -48,7 +48,7 @@ object RoleTypes extends Enumeration {
                                          isAssignable = false)
   val OrganizationOwner   = new RoleType(22, -5, classOf[OrganizationRole], Absolute, "Owner",        Purple,
                                          isAssignable = false)
-  val OrganizationAdmin   = new RoleType(26, -9, classOf[OrganizationRole], Absolute, "Admin",        Purple)
+  val OrganizationAdmin   = new RoleType(26, -9, classOf[OrganizationRole], Lifted,   "Admin",        Purple)
   val OrganizationDev     = new RoleType(23, -6, classOf[OrganizationRole], Standard, "Developer",    Transparent)
   val OrganizationEditor  = new RoleType(24, -7, classOf[OrganizationRole], Limited,  "Editor",       Transparent)
   val OrganizationSupport = new RoleType(25, -8, classOf[OrganizationRole], Default,  "Support",      Transparent)

--- a/app/ore/permission/role/Trust.scala
+++ b/app/ore/permission/role/Trust.scala
@@ -26,6 +26,11 @@ case object Limited extends Trust { override val level = 1 }
 case object Standard extends Trust { override val level = 2 }
 
 /**
+  * User that can perform any action but they are not on top.
+  */
+case object Lifted extends Trust { override val level = 3 }
+
+/**
   * User is absolutely trusted and may perform any action.
   */
-case object Absolute extends Trust { override val level = 3 }
+case object Absolute extends Trust { override val level = 4 }


### PR DESCRIPTION
Org Owners & Admins had the same Trust Level. Owners couldn't modify
Admin positions because they had Absolute Trust. They are now ordered
correctly, and Admins can modify the positions of everyone except the
Owner.

Closes #364
Closes #365