### PR TITLE
Ignore null Tag data

### DIFF
--- a/app/views/projects/tag.scala.html
+++ b/app/views/projects/tag.scala.html
@@ -1,9 +1,9 @@
 @import models.project.Tag
 
 @(tag: Tag)
-@if(tag.data.equals("")) {
+@if(tag.data.isEmpty || tag.data.equals("null")) {
     <div class="tags">
-        <span style="color: @tag.color.foreground; background-color:@tag.color.background; borer-color: @tag.color.background" class="tag">@tag.name</span>
+        <span style="color: @tag.color.foreground; background-color:@tag.color.background; border-color: @tag.color.background" class="tag">@tag.name</span>
     </div>
 } else {
     <div class="tags has-addons">

--- a/public/javascripts/versionList.js
+++ b/public/javascripts/versionList.js
@@ -57,7 +57,7 @@ function loadVersions(increment, scrollTop) {
                 tags.forEach(function (tag) {
                     var style = "background:" + tag.backgroundColor +";border-color:" + tag.backgroundColor + ";color:" + tag.foregroundColor;
 
-                    if(tag.data !== "") {
+                    if(tag.data !== "" && tag.data !== "null") {
                         tagsHtml += "<div class='tags has-addons'><span style='" + style + "' class='tag'>" + tag.name + "</span><span class='tag'>" + tag.data + "</span></div>";
                     } else {
                         tagsHtml += "<div class='tags'><span style='" + style + "' class='tag'>" + tag.name + "</span></div>";


### PR DESCRIPTION
Some of the tags have "null" for their data, which came from improper
version stripping in the older versions of Ore. We don't want to
display null data, so we'll treat it as if it were blank.

I also fixed a typo in the CSS.

Signed-off-by: Jadon Fowler <jadonflower@gmail.com>