### PR TITLE
Add a mime-keyed CSP filter

### DIFF
--- a/app/filters/MimeKeyedCspFilter.scala
+++ b/app/filters/MimeKeyedCspFilter.scala
@@ -1,0 +1,68 @@
+package filters
+
+import javax.inject.{Inject, Singleton}
+
+import akka.stream.Materializer
+import play.api.Configuration
+import play.api.http.HeaderNames.CONTENT_TYPE
+import play.api.mvc.{Filter, RequestHeader, Result}
+import play.filters.headers.SecurityHeadersFilter.CONTENT_SECURITY_POLICY_HEADER
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class MimeKeyedCspFilter @Inject()(implicit val mat: Materializer, ec: ExecutionContext, conf: Configuration) extends Filter {
+
+    private type CspSpec = Map[String, Seq[String]]
+
+    private val keyWords = Set("self", "unsafe-inline", "none")
+    private val defaultMime: String = compileHeader(readCspSpec(conf.getConfig("filters.csp.default")))
+    private val mimeLookup: Map[String, String] = {
+        conf.getConfig("filters.csp.per-mime") match {
+            case Some(perMime) => perMime.keys.map(k => (k, compileHeader(readCspSpec(perMime.getConfig(k))))).toMap
+            case None => Map.empty
+        }
+    }
+
+    private def readCspSpec(conf: Option[Configuration]): CspSpec = {
+        conf match {
+            case Some(defaults) =>
+                defaults.keys.map { k =>
+                    (k, defaults.getStringList(k).map(_.asScala).getOrElse(Seq.empty))
+                }.toMap.filter(_._2.nonEmpty)
+            case None => Map.empty
+        }
+    }
+
+    private def compileHeader(section: CspSpec): String = {
+        val parts = for ((key, values) <- section) yield {
+            val combinedValue = values.map {
+                case v if keyWords.contains(v) => s"'$v'"
+                case v => v
+            }.mkString(" ")
+            s"${key.toLowerCase} $combinedValue"
+        }
+
+        parts.mkString("; ")
+    }
+
+    private def detectMime(request: RequestHeader): Option[String] = {
+        request.path match {
+            case p if p.endsWith(".svg") => Some("image/svg")
+            case _ => None
+        }
+    }
+
+    override def apply(next: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
+        next(request) map { result =>
+            val contentType = result.header.headers.get(CONTENT_TYPE) match {
+                case ct @ Some(_) => ct
+                case _ => detectMime(request)
+            }
+            val csp = contentType.flatMap(mimeLookup.get).getOrElse(defaultMime)
+            result.withHeaders(CONTENT_SECURITY_POLICY_HEADER -> csp)
+        }
+    }
+
+}

--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -36,6 +36,7 @@ play {
     ws.timeout.connection              =   10000
     filters.headers.contentSecurityPolicy = "default-src 'self'; script-src 'self' '%NONCE-SOURCE%' https://forums.spongepowered.org https://forums-cdn.spongepowered.org https://www.google-analytics.com/analytics.js; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://forums-cdn.spongepowered.org; img-src 'self' https:; font-src 'self' https://fonts.gstatic.com; frame-src https://forums.spongepowered.org; frame-ancestors 'none'; block-all-mixed-content"
     filters.headers.contentSecurityPolicy = ${?CONTENT_SECURITY_POLICY}
+    filters.enabled                   += "filters.MimeKeyedCspFilter"
     filters.csrf.body.bufferSize       =   1000000
 }
 
@@ -226,4 +227,40 @@ sponge {
           "link": "https://www.yourkit.com/"
         }
     ]
+}
+
+filters {
+    csp {
+        default {
+            default-src = ["self"]
+            script-src = [
+                "self",
+                "'%NONCE-SOURCE%'"
+                "https://forums.spongepowered.org"
+                "https://forums-cdn.spongepowered.org"
+                "https://www.google-analytics.com/analytics.js"
+            ]
+            style-src = [
+                "self"
+                "unsafe-inline"
+                "https://fonts.googleapis.com"
+                "https://forums-cdn.spongepowered.org"
+            ]
+            img-src = [
+                "self",
+                "https:"
+            ]
+            font-src = [
+                "self"
+                "https://fonts.gstatic.com"
+            ]
+            frame-src = [
+                "https://forums.spongepowered.org"
+            ]
+            frame-ancestors = [
+                "none"
+            ]
+            block-all-mixed-content = []
+        }
+    }
 }


### PR DESCRIPTION
@Faithcaio asked me to PR this

I backported this from a Play 2.6 project.
The filter has 2 advantages over Play's standard filter:
1. Different Content-Types can receive different a CSP header which is useful to support SVGs with inline style.
2. The configuration of the header is done in a HOCON map instead of a single string