### PR TITLE
Fix child page list rendering correct if feched by ajax

### DIFF
--- a/public/javascripts/pageCollapse.js
+++ b/public/javascripts/pageCollapse.js
@@ -16,14 +16,15 @@ function bindExpand(e) {
                 listItem.after(div);
                 for (var i = 0; i < childPages.length; i++) {
                     var page = childPages[i];
-                    div.append(
+                    var childPage = $(
                         '<li class="list-group-item page-item-child">' +
                         '<a href=""></a>' +
                         '</li>'
                     );
-                    var link = div.find("li a");
+                    var link = childPage.find('a');
                     link.attr("href", '/' + namespace + '/pages/' + page.name);
-                    link.text(page.name) // this will sanitize the input
+                    link.text(page.name); // this will sanitize the input
+                    div.append(childPage);
                 }
                 $this.removeClass('page-expand')
                     .addClass('page-collapse')


### PR DESCRIPTION
If you open a collapsed menu it shows the wrong pages

Old:
![schermafbeelding 2018-02-07 om 11 12 04](https://user-images.githubusercontent.com/3961526/35910704-bede44e0-0bf7-11e8-8b66-e5b17698f78c.png)


Fixed:
![schermafbeelding 2018-02-07 om 11 11 20](https://user-images.githubusercontent.com/3961526/35910683-a89f715e-0bf7-11e8-9fc0-7cb4df64960b.png)
