### PR TITLE
Use non breaking space so safari renders space correct

### DIFF
--- a/app/views/users/view.scala.html
+++ b/app/views/users/view.scala.html
@@ -165,7 +165,7 @@
 
                 <div class="user-info">
                     @defining(user.projects.size) { size =>
-                        <i class="minor">@size @if(size == 1) { project } else { projects }</i><br/>
+                        <i class="minor">@size&nbsp;@if(size == 1){project}else{projects}</i><br/>
                     }
                     <i class="minor">
                     @messages(


### PR DESCRIPTION
Safari wan't rendering the space between the number and word correctly by using a `&nbsp;` it works.

Old:
<img width="228" alt="schermafbeelding 2018-03-01 om 11 22 17" src="https://user-images.githubusercontent.com/3961526/36839646-e4d19bf0-1d42-11e8-9c9b-9b87d59855cb.png">

New:
<img width="230" alt="schermafbeelding 2018-03-01 om 11 22 01" src="https://user-images.githubusercontent.com/3961526/36839638-e0a3906a-1d42-11e8-832a-baa72e21d9b6.png">
