### PR TITLE
Allow sending a changelog when using the deploy API endpoint

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -211,6 +211,7 @@ final class ApiController @Inject()(api: OreRestfulApi,
                     case Right(pendingVersion) =>
                       pendingVersion.createForumPost = formData.createForumPost
                       pendingVersion.channelName = formData.channel.name
+                      formData.changelog.foreach(pendingVersion.underlying.setDescription)
                       pendingVersion.complete().map { newVersion =>
                         if (formData.recommended)
                           projectData.project.setRecommendedVersion(newVersion._1)

--- a/app/form/OreForms.scala
+++ b/app/form/OreForms.scala
@@ -9,7 +9,7 @@ import form.organization.{OrganizationAvatarUpdate, OrganizationMembersUpdate, O
 import form.project._
 import javax.inject.Inject
 import models.api.ProjectApiKey
-import models.project.Channel
+import models.project.{Channel, Page}
 import models.project.Page._
 import models.user.role.ProjectRole
 import ore.OreConfig
@@ -256,7 +256,8 @@ class OreForms @Inject()(implicit config: OreConfig, factory: ProjectFactory, se
     "apiKey" -> nonEmptyText,
     "channel" -> channel,
     "recommended" -> default(boolean, true),
-    "forumPost" -> default(boolean, request.data.settings.forumSync))
+    "forumPost" -> default(boolean, request.data.settings.forumSync),
+    "changelog" -> optional(text(minLength = Page.MinLength, maxLength = Page.MaxLength)))
   (VersionDeployForm.apply)(VersionDeployForm.unapply))
 
   lazy val ReviewDescription = Form(single("content" -> text))

--- a/app/form/project/VersionDeployForm.scala
+++ b/app/form/project/VersionDeployForm.scala
@@ -2,4 +2,9 @@ package form.project
 
 import models.project.Channel
 
-case class VersionDeployForm(apiKey: String, channel: Channel, recommended: Boolean, createForumPost: Boolean)
+case class VersionDeployForm(
+    apiKey: String,
+    channel: Channel,
+    recommended: Boolean,
+    createForumPost: Boolean,
+    changelog: Option[String])


### PR DESCRIPTION
Does as it says. Allows sending an optional changelog when using the deploy API endpoint. Closes #428