### PR TITLE
Fix None.get in project create

### DIFF
--- a/app/views/projects/versions/create.scala.html
+++ b/app/views/projects/versions/create.scala.html
@@ -146,7 +146,7 @@
                                             <td class="rv">
                                                 <div class="checkbox-inline">
                                                     <input form="form-publish" name="forum-post" type="checkbox"
-                                                            @if(project.settings.forumSync) { checked } value="true"/>
+                                                            @if(!project.id.isDefined || project.settings.forumSync) { checked } value="true"/>
                                                 </div>
                                                 <div class="clearfix"></div>
                                             </td>


### PR DESCRIPTION
When creating a new project it throws a None.get on ProjectSettings this PR fixes that.