### PR TITLE
Fix content security policy to work with analytics

### DIFF
--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -244,7 +244,7 @@ filters {
                 "'%NONCE-SOURCE%'"
                 "https://forums.spongepowered.org"
                 "https://forums-cdn.spongepowered.org"
-                "https://www.google-analytics.com/analytics.js"
+                "https://www.google-analytics.com"
             ]
             style-src = [
                 "self"


### PR DESCRIPTION
As of the [CSP FAQ](https://content-security-policy.com/faq/) this should work with google analytics.
Fixes #489