### PR TITLE
Fix Role Clearing

### DIFF
--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -104,6 +104,8 @@ case class Project(override val id: Option[Int] = None,
 
     def newMember(userId: Int): MemberType = new ProjectMember(this.model, userId)
 
+    def clearRoles(user: User): Unit = this.roleAccess.removeAll({ s => (s.userId === user.id.get) && (s.projectId === id.get) })
+
   }
 
   def this(pluginId: String, name: String, owner: String, ownerId: Int) = {

--- a/app/models/user/Organization.scala
+++ b/app/models/user/Organization.scala
@@ -3,10 +3,11 @@ package models.user
 import java.sql.Timestamp
 
 import com.google.common.base.Preconditions._
+import db.impl.OrePostgresDriver.api._
 import db.impl.access.UserBase
 import db.impl.model.OreModel
-import db.impl.{OrganizationMembersTable, OrganizationRoleTable, OrganizationTable}
 import db.impl.table.ModelKeys._
+import db.impl.{OrganizationMembersTable, OrganizationRoleTable, OrganizationTable}
 import db.{Model, Named}
 import models.user.role.OrganizationRole
 import ore.organization.OrganizationMember
@@ -55,6 +56,8 @@ case class Organization(override val id: Option[Int] = None,
     val model: ModelType = Organization.this
 
     def newMember(userId: Int) = new OrganizationMember(this.model, userId)
+
+    def clearRoles(user: User): Unit = this.roleAccess.removeAll({ s => (s.userId === user.id.get) && (s.organizationId === id.get) })
 
   }
 

--- a/app/ore/user/MembershipDossier.scala
+++ b/app/ore/user/MembershipDossier.scala
@@ -33,10 +33,15 @@ trait MembershipDossier {
 
   private def association
   = this.model.schema.getAssociation[MembersTable, User](this.membersTableClass, this.model)
-  private def roleAccess: ModelAccess[RoleType] = this.model.service.access[RoleType](roleClass)
+  def roleAccess: ModelAccess[RoleType] = this.model.service.access[RoleType](roleClass)
   private def addMember(user: User) = this.association.add(user)
 
-  private def clearRoles(user: User) = this.roleAccess.removeAll(_.userId === user.id.get)
+  /**
+    * Clears the roles of a User
+    *
+    * @param user User instance
+    */
+  def clearRoles(user: User): Unit
 
   /**
     * Constructs a new member object of the MemberType.


### PR DESCRIPTION
Role Clearing wasn't taking into account the ID of the org/project that
was being removed.

clearRoles(User) was made an abstract function in MembershipDossier so
that implementation of it could access the specific Table members
needed to check against (Project#membership defines the MembersTable
  to be ProjectMembersTable which contains a projectId to check
  against in its implementation of clearRoles).

Signed-off-by: Jadon Fowler <jadonflower@gmail.com>