### PR TITLE
Add that non-home pages have a longer max length

### DIFF
--- a/app/form/OreForms.scala
+++ b/app/form/OreForms.scala
@@ -171,8 +171,16 @@ class OreForms @Inject()(implicit config: OreConfig, factory: ProjectFactory, se
     "parent-id" -> optional(number),
     "name" -> optional(text),
     "content" -> optional(text(
-      maxLength = MaxLength
-    )))(PageSaveForm.apply)(PageSaveForm.unapply))
+      maxLength = MaxLengthPage
+    )))(PageSaveForm.apply)(PageSaveForm.unapply) verifying("error.maxLength", pageSaveForm => {
+      val isHome = pageSaveForm.parentId.isEmpty && pageSaveForm.name.contains(HomeName)
+      val pageSize = pageSaveForm.content.getOrElse("").length
+      if (isHome)
+        pageSize <= MaxLength
+      else
+        pageSize <= MaxLengthPage
+    })
+  )
 
   /**
     * Submits a tagline change for a User.

--- a/app/models/project/Page.scala
+++ b/app/models/project/Page.scala
@@ -85,7 +85,7 @@ case class Page(override val id: Option[Int] = None,
     */
   def setContents(_contents: String)(implicit ec: ExecutionContext): Future[Page] = {
     checkNotNull(_contents, "null contents", "")
-    checkArgument(_contents.length <= MaxLength, "contents too long", "")
+    checkArgument((this.isHome && _contents.length <= MaxLength) || _contents.length <= MaxLengthPage, "contents too long", "")
     this._contents = _contents
     if (!isDefined) Future.successful(this)
     else {
@@ -267,9 +267,14 @@ object Page {
   def MinLength(implicit config: OreConfig): Int = config.pages.get[Int]("min-len")
 
   /**
-    * The maximum amount of characters a page may have.
+    * The maximum amount of characters the home page may have.
     */
   def MaxLength(implicit config: OreConfig): Int = config.pages.get[Int]("max-len")
+
+  /**
+    * The maximum amount of characters a page may have.
+    */
+  def MaxLengthPage(implicit config: OreConfig): Int = config.pages.get[Int]("page.max-len")
 
   /**
     * Returns a template for new Pages.

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -538,7 +538,7 @@ case class Project(override val id: Option[Int] = None,
       case None => Page.Template(name, Page.HomeMessage)
       case Some(text) =>
         checkNotNull(text, "null contents", "")
-        checkArgument(text.length <= Page.MaxLength, "contents too long", "")
+        checkArgument(text.length <= Page.MaxLengthPage, "contents too long", "")
         text
     }
     val page = new Page(this.id.get, name, c, true, parentId)

--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -90,6 +90,7 @@ ore {
         home.message = "Welcome to your new project!"
         min-len = 15
         max-len = 32000
+        page.max-len = 75000
         name.max-len = 255
     }
     


### PR DESCRIPTION
Home pages (and new version descriptions) still have the max length of 32000
Other pages now have a character limit of 75000

Fixes #515 