### PR TITLE
Don't reuse code to check if a project is public

### DIFF
--- a/app/models/project/Visibility.scala
+++ b/app/models/project/Visibility.scala
@@ -1,6 +1,9 @@
 package models.project
 
+import db.ModelFilter
 import db.impl.OrePostgresDriver
+import db.impl.OrePostgresDriver.api._
+import db.impl.model.common.Hideable
 import db.table.MappedType
 import ore.permission.{Permission, ReviewProjects}
 import slick.jdbc.JdbcType
@@ -12,6 +15,12 @@ object VisibilityTypes extends Enumeration {
   val NeedsChanges    = Visibility(3, "needsChanges"  , ReviewProjects, true,     "striped project-needsChanges")
   val NeedsApproval   = Visibility(4, "needsApproval" , ReviewProjects, false,    "striped project-needsChanges")
   val SoftDelete      = Visibility(5, "softDelete"    , ReviewProjects, true,     "striped project-hidden")
+
+  def isPublic(visibility: Visibility): Boolean = visibility == Public || visibility == New
+
+  val isPublicFilter: ModelFilter[Hideable] =
+    ModelFilter[Hideable](_.visibility === Public) +||
+      ModelFilter[Hideable](_.visibility === New)
 
   def withId(id: Int): Visibility = {
     this.apply(id).asInstanceOf[Visibility]

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -338,7 +338,7 @@ case class User(override val id: Option[Int] = None,
     val starsPerPage = this.config.users.get[Int]("stars-per-page")
     val limit = if (page < 1) -1 else starsPerPage
     val offset = (page - 1) * starsPerPage
-    val filter = ModelFilter[Project](_.visibility === VisibilityTypes.Public) +|| ModelFilter[Project](_.visibility === VisibilityTypes.New)
+    val filter = VisibilityTypes.isPublicFilter
     this.schema.getAssociation[ProjectStarsTable, Project](classOf[ProjectStarsTable], this)
       .sorted(ordering = _.name, filter = filter.fn, limit = limit, offset = offset)
   }

--- a/app/ore/rest/OreRestfulApi.scala
+++ b/app/ore/rest/OreRestfulApi.scala
@@ -187,18 +187,12 @@ trait OreRestfulApi {
     val tableVersion = TableQuery[VersionTable]
     val tableChannels = TableQuery[ChannelTable]
 
-    val allProjects = for {
+    for {
       p <- tableProject
       v <- tableVersion if p.recommendedVersionId === v.id
       c <- tableChannels if v.channelId === c.id
-    } yield {
-      (p, v, c)
-    }
-
-    allProjects.filter { case (p, v, c) =>
-      p.visibility =!= VisibilityTypes.SoftDelete &&
-      p.visibility =!= VisibilityTypes.NeedsChanges
-    }
+      if VisibilityTypes.isPublicFilter.fn(p)
+    } yield (p, v, c)
   }
 
   /**


### PR DESCRIPTION
Quick bug fix I found while looking over some code. At the moment it's possible to get a project that has submitted for approval through the API.