### PR TITLE
Replace Option id and timestamp with custom types

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -88,7 +88,7 @@ final class ApiController @Inject()(api: OreRestfulApi,
 
   def createKey(version: String, pluginId: String): Action[AnyContent] =
     (Action andThen AuthedProjectActionById(pluginId) andThen ProjectPermissionAction(EditApiKeys)) async { implicit request =>
-      val projectId = request.data.project.id.get
+      val projectId = request.data.project.id.value
       val res = for {
         keyType <- bindFormOptionT[Future](this.forms.ProjectApiKeyCreate)
         if keyType == Deployment
@@ -109,7 +109,7 @@ final class ApiController @Inject()(api: OreRestfulApi,
     (AuthedProjectActionById(pluginId) andThen ProjectPermissionAction(EditApiKeys)) { implicit request =>
       val res = for {
         key <- bindFormOptionT[Id](this.forms.ProjectApiKeyRevoke)
-        if key.projectId == request.data.project.id.get
+        if key.projectId == request.data.project.id.value
       } yield {
         key.remove()
         Ok
@@ -191,7 +191,7 @@ final class ApiController @Inject()(api: OreRestfulApi,
 
           val compiled = Compiled(queryApiKey _)
 
-          val apiKeyExists: Future[Boolean] = this.service.DB.db.run(compiled(Deployment, formData.apiKey, projectData.project.id.get).result)
+          val apiKeyExists: Future[Boolean] = this.service.DB.db.run(compiled(Deployment, formData.apiKey, projectData.project.id.value).result)
 
           EitherT.liftF(apiKeyExists)
             .filterOrElse(apiKey => apiKey, Unauthorized(error("apiKey", "api.deploy.invalidKey")))

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -114,7 +114,7 @@ final class ApiController @Inject()(api: OreRestfulApi,
         key.remove()
         Ok
       }
-      UserActionLogger.log(request.request, LoggedAction.ProjectSettingsChanged, request.data.project.id.get, s"${request.user.name} removed an ApiKey", "")
+      UserActionLogger.log(request.request, LoggedAction.ProjectSettingsChanged, request.data.project.id.value, s"${request.user.name} removed an ApiKey", "")
       res.getOrElse(BadRequest)
     }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -90,7 +90,7 @@ final class Application @Inject()(data: DataHelper,
     // Get categories and sorting strategy
 
     val canHideProjects = request.data.globalPerm(HideProjects)
-    val currentUserId = request.data.currentUser.flatMap(_.id).getOrElse(-1)
+    val currentUserId = request.data.currentUser.map(_.id.value).getOrElse(-1)
 
     val ordering = sort.flatMap(ProjectSortingStrategies.withId).getOrElse(ProjectSortingStrategies.Default)
     val pcat = platformCategory.flatMap(p => PlatformCategory.getPlatformCategories.find(_.name.equalsIgnoreCase(p)))
@@ -165,7 +165,7 @@ final class Application @Inject()(data: DataHelper,
     val offset = page * limit
 
     val data = this.service.DB.db.run(queryQueue.result).flatMap { list =>
-      service.DB.db.run(queryReviews(list.map(_._1.id.get)).result).map { reviewList =>
+      service.DB.db.run(queryReviews(list.map(_._1.id.value)).result).map { reviewList =>
         reviewList.groupBy(_._1.versionId)
       } map { reviewsByVersion =>
         (list, reviewsByVersion)
@@ -174,7 +174,7 @@ final class Application @Inject()(data: DataHelper,
       val reviewData = reviewsByVersion.mapValues { reviews =>
 
         reviews.filter { case (review, _) =>
-          review.createdAt.isDefined && review.endedAt.isEmpty
+          review.createdAt.unsafeToOption.isDefined && review.endedAt.isEmpty
         }.sorted(Review.ordering).headOption.map { case (r, a) =>
           (r, true, a) // Unfinished Review
         } orElse reviews.sorted(Review.ordering).headOption.map { case (r, a) =>
@@ -183,7 +183,7 @@ final class Application @Inject()(data: DataHelper,
       }
 
       list.map { case (v, p, c, a, u) =>
-        (v, p, c, a, u, reviewData.getOrElse(v.id.get, None))
+        (v, p, c, a, u, reviewData.getOrElse(v.id.value, None))
       }
     }
     data map { list =>
@@ -333,26 +333,23 @@ final class Application @Inject()(data: DataHelper,
     */
   def showActivities(user: String): Action[AnyContent] = (Authenticated andThen PermissionAction[AuthRequest](ReviewProjects)) async { implicit request =>
     this.users.withName(user).semiFlatMap { u =>
-      val activities: Future[Seq[(Object, Option[Project])]] = u.id match {
-        case None => Future.successful(Seq.empty)
-        case Some(id) =>
-          val reviews = this.service.access[Review](classOf[Review])
-            .filter(_.userId === id)
-            .map(_.take(20).map { review => review ->
-              this.service.access[Version](classOf[Version]).filter(_.id === review.versionId).flatMap { version =>
-                this.projects.find(_.id === version.head.projectId).value
-              }
-            })
-          val flags = this.service.access[Flag](classOf[Flag])
-            .filter(_.resolvedBy === id)
-            .map(_.take(20).map(flag => flag -> this.projects.find(_.id === flag.projectId).value))
+      val id = u.id.value
+      val reviews = this.service.access[Review](classOf[Review])
+        .filter(_.userId === id)
+        .map(_.take(20).map { review => review ->
+          this.service.access[Version](classOf[Version]).filter(_.id === review.versionId).flatMap { version =>
+            this.projects.find(_.id === version.head.projectId).value
+          }
+        })
+      val flags = this.service.access[Flag](classOf[Flag])
+        .filter(_.resolvedBy === id)
+        .map(_.take(20).map(flag => flag -> this.projects.find(_.id === flag.projectId).value))
 
-          val allActivities = reviews.flatMap(r => flags.map(_ ++ r))
+      val allActivities = reviews.flatMap(r => flags.map(_ ++ r))
 
-          allActivities.flatMap(Future.traverse(_) {
-            case (k, fv) => fv.map(k -> _)
-          }.map(_.sortWith(sortActivities)))
-      }
+      val activities = allActivities.flatMap(Future.traverse(_) {
+        case (k, fv) => fv.map(k -> _)
+      }.map(_.sortWith(sortActivities)))
       activities.map(a => Ok(views.users.admin.activity(u, a)))
     }.getOrElse(NotFound)
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -174,7 +174,7 @@ final class Application @Inject()(data: DataHelper,
       val reviewData = reviewsByVersion.mapValues { reviews =>
 
         reviews.filter { case (review, _) =>
-          review.createdAt.unsafeToOption.isDefined && review.endedAt.isEmpty
+          review.endedAt.isEmpty
         }.sorted(Review.ordering).headOption.map { case (r, a) =>
           (r, true, a) // Unfinished Review
         } orElse reviews.sorted(Review.ordering).headOption.map { case (r, a) =>

--- a/app/controllers/Organizations.scala
+++ b/app/controllers/Organizations.scala
@@ -71,7 +71,7 @@ class Organizations @Inject()(forms: OreForms,
         Future.successful(Redirect(failCall).withError("error.org.disabled"))
       else {
         bindFormEitherT[Future](this.forms.OrganizationCreate)(hasErrors => FormError(failCall, hasErrors)).flatMap { formData =>
-          this.organizations.create(formData.name, user.id.get, formData.build()).bimap(
+          this.organizations.create(formData.name, user.id.value, formData.build()).bimap(
             error => Redirect(failCall).withError(error),
             organization => Redirect(routes.Users.showProjects(organization.name, None))
           )

--- a/app/controllers/Reviews.scala
+++ b/app/controllers/Reviews.scala
@@ -57,7 +57,7 @@ final class Reviews @Inject()(data: DataHelper,
           Future.traverse(reviews)(r => r.userBase.get(r.userId).map(_.name).value.tupleLeft(r))
         )
       } yield {
-        val unfinished = reviews.filter(r => r.createdAt.unsafeToOption.isDefined && r.endedAt.isEmpty).sorted(Review.ordering2).headOption
+        val unfinished = reviews.filter(_.endedAt.isEmpty).sorted(Review.ordering2).headOption
         implicit val v: Version = version
         Ok(views.users.admin.reviews(unfinished, rv))
       }
@@ -248,7 +248,7 @@ final class Reviews @Inject()(data: DataHelper,
         version <- getProjectVersion(author, slug, versionString)
       } yield {
 
-        UserActionLogger.log(request, LoggedAction.VersionNonReviewChanged, version.id.getOrElse(-1), s"In review queue: ${version.isNonReviewed}", s"In review queue: ${!version.isNonReviewed}")
+        UserActionLogger.log(request, LoggedAction.VersionNonReviewChanged, version.id.value, s"In review queue: ${version.isNonReviewed}", s"In review queue: ${!version.isNonReviewed}")
         version.setIsNonReviewed(!version.isNonReviewed)
 
         Redirect(routes.Reviews.showReviews(author, slug, versionString))

--- a/app/controllers/Users.scala
+++ b/app/controllers/Users.scala
@@ -158,7 +158,7 @@ class Users @Inject()(fakeUser: FakeUser,
 
   private def queryUserProjects(user: User) = {
     queryProjectRV filter { case (p, v) =>
-      p.userId === user.id.get
+      p.userId === user.id.value
     } sortBy { case (p, v) =>
       (p.stars.desc, p.name.asc)
     }

--- a/app/controllers/Users.scala
+++ b/app/controllers/Users.scala
@@ -192,7 +192,7 @@ class Users @Inject()(fakeUser: FakeUser,
       if (tagline.length > maxLen) {
         Redirect(ShowUser(user)).flashing("error" -> request.messages.apply("error.tagline.tooLong", maxLen))
       } else {
-        UserActionLogger.log(request, LoggedAction.UserTaglineChanged, user.id.get, tagline, user.tagline.getOrElse("null"))
+        UserActionLogger.log(request, LoggedAction.UserTaglineChanged, user.id.value, tagline, user.tagline.getOrElse("null"))
         user.setTagline(tagline)
         Redirect(ShowUser(user))
       }
@@ -221,7 +221,7 @@ class Users @Inject()(fakeUser: FakeUser,
 
         // Send email notification
         this.mailer.push(this.emails.create(user, this.emails.PgpUpdated))
-        UserActionLogger.log(request, LoggedAction.UserPgpKeySaved, user.id.get, "", "")
+        UserActionLogger.log(request, LoggedAction.UserPgpKeySaved, user.id.value, "", "")
 
         Redirect(ShowUser(username)).flashing("pgp-updated" -> "true")
       }
@@ -243,7 +243,7 @@ class Users @Inject()(fakeUser: FakeUser,
       else {
         user.setPgpPubKey(null)
         user.setLastPgpPubKeyUpdate(this.service.theTime)
-        UserActionLogger.log(request, LoggedAction.UserPgpKeyRemoved, user.id.get, "", "")
+        UserActionLogger.log(request, LoggedAction.UserPgpKeyRemoved, user.id.value, "", "")
         Redirect(ShowUser(username)).flashing("pgp-updated" -> "true")
       }
     }

--- a/app/controllers/project/Pages.scala
+++ b/app/controllers/project/Pages.scala
@@ -57,8 +57,7 @@ class Pages @Inject()(forms: OreForms,
     if (parts.length == 2) {
       project.pages
         .find(equalsIgnoreCase(_.slug, parts(0)))
-        .subflatMap(_.id)
-        .getOrElse(-1)
+        .fold(0)(_.id.value)
         .flatMap { parentId =>
           project.pages.filter(equalsIgnoreCase(_.slug, parts(1))).map(seq => seq.find(_.parentId == parentId)).map((_, false))
         }
@@ -112,7 +111,7 @@ class Pages @Inject()(forms: OreForms,
 
     for {
       (name, parentId) <- if (parts.size != 2) Future.successful((parts(0), -1)) else {
-        data.project.pages.find(equalsIgnoreCase(_.slug, parts(0))).subflatMap(_.id).getOrElse(-1).map((parts(1), _))
+        data.project.pages.find(equalsIgnoreCase(_.slug, parts(0))).fold(-1)(_.id.value).map((parts(1), _))
       }
       (p, pages) <- (
         data.project.pages.find(equalsIgnoreCase(_.slug, name)).getOrElseF(data.project.getOrCreatePage(name, parentId)),
@@ -151,7 +150,7 @@ class Pages @Inject()(forms: OreForms,
         val parentId = pageData.parentId.getOrElse(-1)
         //noinspection ComparingUnrelatedTypes
         data.project.rootPages.flatMap { rootPages =>
-          if (parentId != -1 && !rootPages.filterNot(_.name.equals(Page.HomeName)).exists(_.id.get == parentId)) {
+          if (parentId != -1 && !rootPages.filterNot(_.name.equals(Page.HomeName)).exists(_.id.value == parentId)) {
             Future.successful(BadRequest("Invalid parent ID."))
           } else {
             val content = pageData.content
@@ -161,7 +160,7 @@ class Pages @Inject()(forms: OreForms,
               val parts = page.split("/")
 
               val created = if (parts.size == 2) {
-                data.project.pages.find(equalsIgnoreCase(_.slug, parts(0))).subflatMap(_.id).getOrElse(-1).flatMap { parentId =>
+                data.project.pages.find(equalsIgnoreCase(_.slug, parts(0))).fold(-1)(_.id.value).flatMap { parentId =>
                   val pageName = pageData.name.getOrElse(parts(1))
                   data.project.getOrCreatePage(pageName, parentId, pageData.content)
                 }

--- a/app/controllers/project/Pages.scala
+++ b/app/controllers/project/Pages.scala
@@ -172,7 +172,7 @@ class Pages @Inject()(forms: OreForms,
                 if (pageData.content.isDefined) {
                   val oldPage = createdPage.contents
                   val newPage = pageData.content.get
-                  UserActionLogger.log(request.request, LoggedAction.ProjectPageEdited, createdPage.id.getOrElse(-1), newPage, oldPage)
+                  UserActionLogger.log(request.request, LoggedAction.ProjectPageEdited, createdPage.id.value, newPage, oldPage)
                   createdPage.setContents(newPage)
                 } else Future.successful(createdPage)
               } map { _ =>

--- a/app/controllers/project/Projects.scala
+++ b/app/controllers/project/Projects.scala
@@ -179,14 +179,14 @@ class Projects @Inject()(stats: StatTracker,
   private def orgasUserCanUploadTo(user: User): Future[Set[Int]] = {
     for {
       all <- user.organizations.all
-      canCreate <- Future.traverse(all)(org => user can CreateProject in org map { perm => (org.id.get, perm)})
+      canCreate <- Future.traverse(all)(org => user can CreateProject in org map { perm => (org.id.value, perm)})
     } yield {
       // Filter by can Create Project
       val others = canCreate.collect {
         case (id, perm) if perm => id
       }
 
-      others + user.id.get // Add self
+      others + user.id.value // Add self
     }
   }
 
@@ -641,9 +641,9 @@ class Projects @Inject()(stats: StatTracker,
         if (perm) {
           val change = if (newVisibility.showModal) {
             val comment = this.forms.NeedsChanges.bindFromRequest.get.trim
-            request.data.project.setVisibility(newVisibility, comment, request.user.id.get)
+            request.data.project.setVisibility(newVisibility, comment, request.user.id.value)
           } else {
-            request.data.project.setVisibility(newVisibility, "", request.user.id.get)
+            request.data.project.setVisibility(newVisibility, "", request.user.id.value)
           }
 
           this.forums.changeTopicVisibility(request.data.project, VisibilityTypes.isPublic(newVisibility))
@@ -666,7 +666,7 @@ class Projects @Inject()(stats: StatTracker,
   def publish(author: String, slug: String): Action[AnyContent] = SettingsEditAction(author, slug) { implicit request =>
     val data = request.data
     if (data.visibility == VisibilityTypes.New) {
-      data.project.setVisibility(VisibilityTypes.Public, "", request.user.id.get)
+      data.project.setVisibility(VisibilityTypes.Public, "", request.user.id.value)
       UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, data.project.id.getOrElse(-1), VisibilityTypes.Public.nameKey, VisibilityTypes.New.nameKey)
     }
     Redirect(self.show(data.project.ownerName, data.project.slug))
@@ -681,7 +681,7 @@ class Projects @Inject()(stats: StatTracker,
   def sendForApproval(author: String, slug: String): Action[AnyContent] = SettingsEditAction(author, slug) { implicit request =>
     val data = request.data
     if (data.visibility == VisibilityTypes.NeedsChanges) {
-      data.project.setVisibility(VisibilityTypes.NeedsApproval, "", request.user.id.get)
+      data.project.setVisibility(VisibilityTypes.NeedsApproval, "", request.user.id.value)
       UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, data.project.id.getOrElse(-1), VisibilityTypes.NeedsApproval.nameKey, VisibilityTypes.NeedsChanges.nameKey)
     }
     Redirect(self.show(data.project.ownerName, data.project.slug))
@@ -729,7 +729,7 @@ class Projects @Inject()(stats: StatTracker,
     val data = request.data
     val comment = this.forms.NeedsChanges.bindFromRequest.get.trim
     val oldVisibility = data.project.visibility.nameKey
-    data.project.setVisibility(VisibilityTypes.SoftDelete, comment, request.user.id.get).map { _ =>
+    data.project.setVisibility(VisibilityTypes.SoftDelete, comment, request.user.id.value).map { _ =>
 
       this.forums.changeTopicVisibility(data.project, false)
 

--- a/app/controllers/project/Projects.scala
+++ b/app/controllers/project/Projects.scala
@@ -358,7 +358,7 @@ class Projects @Inject()(stats: StatTracker,
           FormError(ShowProject(data.project), hasErrors),
         formData => {
           data.project.flagFor(user, formData.reason, formData.comment)
-          UserActionLogger.log(request.request, LoggedAction.ProjectFlagged, data.project.id.getOrElse(-1), s"Flagged by ${user.name}", s"Not flagged by ${user.name}")
+          UserActionLogger.log(request.request, LoggedAction.ProjectFlagged, data.project.id.value, s"Flagged by ${user.name}", s"Not flagged by ${user.name}")
           Redirect(self.show(author, slug)).flashing("reported" -> "true")
         }
       )
@@ -517,7 +517,7 @@ class Projects @Inject()(stats: StatTracker,
           Files.createDirectories(pendingDir)
         Files.list(pendingDir).iterator().asScala.foreach(Files.delete)
         tmpFile.ref.moveTo(pendingDir.resolve(tmpFile.filename).toFile, replace = true)
-        UserActionLogger.log(request.request, LoggedAction.ProjectIconChanged, data.project.id.getOrElse(-1), "", "") //todo data
+        UserActionLogger.log(request.request, LoggedAction.ProjectIconChanged, data.project.id.value, "", "") //todo data
         Ok
     }
   }
@@ -534,7 +534,7 @@ class Projects @Inject()(stats: StatTracker,
     val fileManager = this.projects.fileManager
     fileManager.getIconPath(data.project).foreach(Files.delete)
     fileManager.getPendingIconPath(data.project).foreach(Files.delete)
-    UserActionLogger.log(request.request, LoggedAction.ProjectIconChanged, data.project.id.getOrElse(-1), "", "") //todo data
+    UserActionLogger.log(request.request, LoggedAction.ProjectIconChanged, data.project.id.value, "", "") //todo data
     Files.delete(fileManager.getPendingIconDir(data.project.ownerName, data.project.name))
     Ok
   }
@@ -569,7 +569,7 @@ class Projects @Inject()(stats: StatTracker,
     } yield {
       val project = request.data.project
       project.memberships.removeMember(user)
-      UserActionLogger.log(request.request, LoggedAction.ProjectMemberRemoved, project.id.getOrElse(-1),
+      UserActionLogger.log(request.request, LoggedAction.ProjectMemberRemoved, project.id.value,
         s"'${user.name}' is not a member of ${project.ownerName}/${project.name}", s"'${user.name}' is a member of ${project.ownerName}/${project.name}")
       Redirect(self.showSettings(author, slug))
     }
@@ -592,7 +592,7 @@ class Projects @Inject()(stats: StatTracker,
           Future.successful(FormError(self.showSettings(author, slug), hasErrors)),
         formData => {
           data.settings.save(data.project, formData).map { _ =>
-            UserActionLogger.log(request.request, LoggedAction.ProjectSettingsChanged, request.data.project.id.getOrElse(-1), "", "") //todo add old new data
+            UserActionLogger.log(request.request, LoggedAction.ProjectSettingsChanged, request.data.project.id.value, "", "") //todo add old new data
             Redirect(self.show(author, slug))
           }
         }
@@ -618,7 +618,7 @@ class Projects @Inject()(stats: StatTracker,
     } yield {
       val data = request.data
       val oldName = data.project.name
-      UserActionLogger.log(request.request, LoggedAction.ProjectRenamed, data.project.id.getOrElse(-1), s"$author/$newName", s"$author/$oldName")
+      UserActionLogger.log(request.request, LoggedAction.ProjectRenamed, data.project.id.value, s"$author/$newName", s"$author/$oldName")
       Redirect(self.show(author, project.slug))
     }
 
@@ -648,7 +648,7 @@ class Projects @Inject()(stats: StatTracker,
 
           this.forums.changeTopicVisibility(request.data.project, VisibilityTypes.isPublic(newVisibility))
 
-          UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, request.data.project.id.getOrElse(-1), newVisibility.nameKey, VisibilityTypes.NeedsChanges.nameKey)
+          UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, request.data.project.id.value, newVisibility.nameKey, VisibilityTypes.NeedsChanges.nameKey)
           change.map(_ => Ok)
         } else {
           Future.successful(Unauthorized)
@@ -667,7 +667,7 @@ class Projects @Inject()(stats: StatTracker,
     val data = request.data
     if (data.visibility == VisibilityTypes.New) {
       data.project.setVisibility(VisibilityTypes.Public, "", request.user.id.value)
-      UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, data.project.id.getOrElse(-1), VisibilityTypes.Public.nameKey, VisibilityTypes.New.nameKey)
+      UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, data.project.id.value, VisibilityTypes.Public.nameKey, VisibilityTypes.New.nameKey)
     }
     Redirect(self.show(data.project.ownerName, data.project.slug))
   }
@@ -682,7 +682,7 @@ class Projects @Inject()(stats: StatTracker,
     val data = request.data
     if (data.visibility == VisibilityTypes.NeedsChanges) {
       data.project.setVisibility(VisibilityTypes.NeedsApproval, "", request.user.id.value)
-      UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, data.project.id.getOrElse(-1), VisibilityTypes.NeedsApproval.nameKey, VisibilityTypes.NeedsChanges.nameKey)
+      UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, data.project.id.value, VisibilityTypes.NeedsApproval.nameKey, VisibilityTypes.NeedsChanges.nameKey)
     }
     Redirect(self.show(data.project.ownerName, data.project.slug))
   }
@@ -712,7 +712,7 @@ class Projects @Inject()(stats: StatTracker,
     (Authenticated andThen PermissionAction[AuthRequest](HardRemoveProject)).async { implicit request =>
       getProject(author, slug).map { project =>
         this.projects.delete(project)
-        UserActionLogger.log(request, LoggedAction.ProjectVisibilityChange, project.id.getOrElse(-1), "deleted", project.visibility.nameKey)
+        UserActionLogger.log(request, LoggedAction.ProjectVisibilityChange, project.id.value, "deleted", project.visibility.nameKey)
         Redirect(ShowHome).withSuccess(request.messages.apply("project.deleted", project.name))
       }.merge
     }
@@ -733,7 +733,7 @@ class Projects @Inject()(stats: StatTracker,
 
       this.forums.changeTopicVisibility(data.project, false)
 
-      UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, data.project.id.getOrElse(-1), data.project.visibility.nameKey, oldVisibility)
+      UserActionLogger.log(request.request, LoggedAction.ProjectVisibilityChange, data.project.id.value, data.project.visibility.nameKey, oldVisibility)
       Redirect(ShowHome).withSuccess(request.messages.apply("project.deleted", data.project.name))
     }
   }

--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -108,7 +108,7 @@ class Versions @Inject()(stats: StatTracker,
         val oldDescription = version.description.getOrElse("")
         val newDescription = description.trim
         version.setDescription(newDescription)
-        UserActionLogger.log(request.request, LoggedAction.VersionDescriptionEdited, version.id.getOrElse(-1), newDescription, oldDescription)
+        UserActionLogger.log(request.request, LoggedAction.VersionDescriptionEdited, version.id.value, newDescription, oldDescription)
         Redirect(self.show(author, slug, versionString))
       }
 
@@ -129,7 +129,7 @@ class Versions @Inject()(stats: StatTracker,
       implicit val r: Requests.AuthRequest[AnyContent] = request.request
       getVersion(request.data.project, versionString).map { version =>
         request.data.project.setRecommendedVersion(version)
-        UserActionLogger.log(request.request, LoggedAction.VersionAsRecommended, version.id.getOrElse(-1), "recommended version", "listed version")
+        UserActionLogger.log(request.request, LoggedAction.VersionAsRecommended, version.id.value, "recommended version", "listed version")
         Redirect(self.show(author, slug, versionString))
       }.merge
     }
@@ -151,7 +151,7 @@ class Versions @Inject()(stats: StatTracker,
         version.setReviewed(reviewed = true)
         version.setReviewer(request.user)
         version.setApprovedAt(this.service.theTime)
-        UserActionLogger.log(request.request, LoggedAction.VersionApproved, version.id.getOrElse(-1), "approved", "unapproved")
+        UserActionLogger.log(request.request, LoggedAction.VersionApproved, version.id.value, "approved", "unapproved")
         Redirect(self.show(author, slug, versionString))
       }.merge
     }
@@ -329,7 +329,7 @@ class Versions @Inject()(stats: StatTracker,
                           if (versionData.recommended)
                             project.setRecommendedVersion(newVersion._1)
                           addUnstableTag(newVersion._1, versionData.unstable)
-                          UserActionLogger.log(request, LoggedAction.VersionUploaded, newVersion._1.id.getOrElse(-1), "published", "null")
+                          UserActionLogger.log(request, LoggedAction.VersionUploaded, newVersion._1.id.value, "published", "null")
                           Redirect(self.show(author, slug, versionString))
                         }
                       }
@@ -338,7 +338,7 @@ class Versions @Inject()(stats: StatTracker,
                 case Some(pendingProject) =>
                   // Found a pending project, create it with first version
                   pendingProject.complete.map { created =>
-                    UserActionLogger.log(request, LoggedAction.ProjectCreated, created._1.id.getOrElse(-1), "created", "null")
+                    UserActionLogger.log(request, LoggedAction.ProjectCreated, created._1.id.value, "created", "null")
                     addUnstableTag(created._2, versionData.unstable)
                     Redirect(ShowProject(author, slug))
                   }
@@ -391,7 +391,7 @@ class Versions @Inject()(stats: StatTracker,
         version <- getProjectVersion(author, slug, versionString)
       } yield {
         this.projects.deleteVersion(version)
-        UserActionLogger.log(request, LoggedAction.VersionDeleted, version.id.getOrElse(-1), s"Deleted: ${comment}", s"${version.visibility}")
+        UserActionLogger.log(request, LoggedAction.VersionDeleted, version.id.value, s"Deleted: ${comment}", s"${version.visibility}")
         Redirect(self.showList(author, slug, None))
       }
       res.merge
@@ -412,9 +412,9 @@ class Versions @Inject()(stats: StatTracker,
       comment <- bindFormEitherT[Future](this.forms.NeedsChanges)(_ => BadRequest)
       version <- getVersion(project, versionString)
       _ <- EitherT.right[Result](this.projects.prepareDeleteVersion(version))
-      _ <- EitherT.right[Result](version.setVisibility(VisibilityTypes.SoftDelete, comment, request.user.id.get))
+      _ <- EitherT.right[Result](version.setVisibility(VisibilityTypes.SoftDelete, comment, request.user.id.value))
     } yield {
-      UserActionLogger.log(oreRequest, LoggedAction.VersionDeleted, version.id.getOrElse(-1), s"SoftDelete: ${comment}", "")
+      UserActionLogger.log(oreRequest, LoggedAction.VersionDeleted, version.id.value, s"SoftDelete: ${comment}", "")
       Redirect(self.showList(author, slug, None))
     }
 

--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -434,9 +434,9 @@ class Versions @Inject()(stats: StatTracker,
       val res = for {
         comment <- bindFormEitherT[Future](this.forms.NeedsChanges)(_ => BadRequest)
         version <- getProjectVersion(author, slug, versionString)
-        _ <- EitherT.right[Result](version.setVisibility(VisibilityTypes.Public, comment, request.user.id.get))
+        _ <- EitherT.right[Result](version.setVisibility(VisibilityTypes.Public, comment, request.user.id.value))
       } yield {
-        UserActionLogger.log(request, LoggedAction.VersionDeleted, version.id.getOrElse(-1), s"Restore: ${comment}", "")
+        UserActionLogger.log(request, LoggedAction.VersionDeleted, version.id.value, s"Restore: ${comment}", "")
         Redirect(self.showList(author, slug, None))
       }
       res.merge

--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -173,7 +173,7 @@ class Versions @Inject()(stats: StatTracker,
       data.project.channels.toSeq.flatMap { allChannels =>
         val visibleNames = channels.fold(allChannels.map(_.name.toLowerCase))(_.toLowerCase.split(',').toSeq)
         val visible = allChannels.filter(ch => visibleNames.contains(ch.name.toLowerCase))
-        val visibleIds = visible.map(_.id.get)
+        val visibleIds = visible.map(_.id.value)
 
         def versionFilter(v: VersionTable): Rep[Boolean] = {
           val inChannel = v.channelId inSetBind visibleIds
@@ -239,7 +239,7 @@ class Versions @Inject()(stats: StatTracker,
           EitherT.leftT[Future, PendingVersion](Redirect(call).withErrors(Option(e.getMessage).toList))
       }
     }.map { pendingVersion =>
-      pendingVersion.underlying.setAuthorId(user.id.getOrElse(-1))
+      pendingVersion.underlying.setAuthorId(user.id.value)
       Redirect(self.showCreatorWithMeta(request.data.project.ownerName, slug, pendingVersion.underlying.versionString))
     }.merge
   }
@@ -355,7 +355,7 @@ class Versions @Inject()(stats: StatTracker,
         .filter(t => t.name === "Unstable" && t.data === "").map { tagsWithVersion =>
         if (tagsWithVersion.isEmpty) {
           val tag = Tag(
-            _versionIds = List(version.id.get),
+            _versionIds = List(version.id.value),
             name = "Unstable",
             data = "",
             color = TagColors.Unstable
@@ -368,7 +368,7 @@ class Versions @Inject()(stats: StatTracker,
           }
         } else {
           val tag = tagsWithVersion.head
-          tag.addVersionId(version.id.get)
+          tag.addVersionId(version.id.value)
           version.addTag(tag)
         }
       }
@@ -505,7 +505,7 @@ class Versions @Inject()(stats: StatTracker,
       .flatMap { tkn =>
         this.warnings.find { warn =>
           (warn.token === tkn) &&
-            (warn.versionId === version.id.get) &&
+            (warn.versionId === version.id.value) &&
             (warn.address === InetString(StatTracker.remoteAddress)) &&
             warn.isConfirmed
         }
@@ -562,7 +562,7 @@ class Versions @Inject()(stats: StatTracker,
           val warning = this.warnings.add(DownloadWarning(
             expiration = expiration,
             token = token,
-            versionId = version.id.get,
+            versionId = version.id.value,
             address = InetString(StatTracker.remoteAddress)))
 
           if (api.getOrElse(false)) {
@@ -608,7 +608,7 @@ class Versions @Inject()(stats: StatTracker,
       implicit val r: OreRequest[_] = request.request
       getVersion(request.data.project, target)
         .filterOrElse(v => !v.isReviewed, Redirect(ShowProject(author, slug)).withError("error.plugin.stateChanged"))
-        .flatMap(version => confirmDownload0(version.id.get, downloadType, token).toRight(Redirect(ShowProject(author, slug)).withError("error.plugin.noConfirmDownload")))
+        .flatMap(version => confirmDownload0(version.id.value, downloadType, token).toRight(Redirect(ShowProject(author, slug)).withError("error.plugin.noConfirmDownload")))
         .map { dl =>
           dl.downloadType match {
             case UploadedFile =>
@@ -655,7 +655,7 @@ class Versions @Inject()(stats: StatTracker,
         user <- this.users.current.value
         _ <- warn.setConfirmed()
         unsafeDownload <- downloads.add(UnsafeDownload(
-          userId = user.flatMap(_.id),
+          userId = user.map(_.id.value),
           address = addr,
           downloadType = dlType))
         _ <- warn.setDownload(unsafeDownload)
@@ -768,7 +768,7 @@ class Versions @Inject()(stats: StatTracker,
       implicit val r: OreRequest[AnyContent] = request.request
       getVersion(project, versionString).semiFlatMap { version =>
         optToken.map { token =>
-          confirmDownload0(version.id.get, Some(JarFile.id), token)(request.request).value.flatMap { _ =>
+          confirmDownload0(version.id.value, Some(JarFile.id), token)(request.request).value.flatMap { _ =>
             sendJar(project, version, optToken, api = true)
           }
         }.getOrElse(sendJar(project, version, optToken, api = true))

--- a/app/controllers/sugar/Actions.scala
+++ b/app/controllers/sugar/Actions.scala
@@ -144,7 +144,7 @@ trait Actions extends Calls with ActionHelpers {
     */
   def isNonceValid(nonce: String)(implicit ec: ExecutionContext): Future[Boolean] = this.signOns.find(_.nonce === nonce).exists {
     signOn =>
-      if (signOn.isCompleted || new Date().getTime - signOn.createdAt.get.getTime > 600000)
+      if (signOn.isCompleted || new Date().getTime - signOn.createdAt.value.getTime > 600000)
         false
       else {
         signOn.setCompleted()
@@ -180,7 +180,7 @@ trait Actions extends Calls with ActionHelpers {
       } yield Actions.this.sso.authenticate(ssoSome, sigSome)(isNonceValid)
 
       OptionT.fromOption[Future](auth).flatMap(identity).cata(Some(Unauthorized), spongeUser =>
-        if (spongeUser.id == request.user.id.get)
+        if (spongeUser.id == request.user.id.value)
           None
         else
           Some(Unauthorized))

--- a/app/db/Model.scala
+++ b/app/db/Model.scala
@@ -1,7 +1,5 @@
 package db
 
-import java.sql.Timestamp
-
 import scala.concurrent.Future
 
 import com.google.common.base.Preconditions.checkNotNull
@@ -13,7 +11,7 @@ import scala.language.implicitConversions
 /**
   * Represents a Model that may or may not exist in the database.
   */
-abstract class Model(val id: Option[Int], val createdAt: Option[Timestamp]) { self =>
+abstract class Model(val id: ObjectId, val createdAt: ObjectTimestamp) { self =>
 
   /** Self referential type */
   type M <: Model { type M = self.M }
@@ -50,7 +48,7 @@ abstract class Model(val id: Option[Int], val createdAt: Option[Timestamp]) { se
     *
     * @return True if defined in database
     */
-  def isDefined: Boolean = this.id.isDefined
+  def isDefined: Boolean = this.id.unsafeToOption.isDefined
 
   /**
     * Returns the ModelActions associated with this Model.
@@ -73,7 +71,7 @@ abstract class Model(val id: Option[Int], val createdAt: Option[Timestamp]) { se
     * @param theTime  Timestamp
     * @return         Copy of model
     */
-  def copyWith(id: Option[Int], theTime: Option[Timestamp]): Model
+  def copyWith(id: ObjectId, theTime: ObjectTimestamp): Model
 
   /**
     * Returns true if this model has been processed internally by some

--- a/app/db/ModelSchema.scala
+++ b/app/db/ModelSchema.scala
@@ -107,7 +107,7 @@ class ModelSchema[M <: Model](val service: ModelService,
     */
   def getChildren[C <: Model](childClass: Class[C], model: M): ModelAccess[C] = {
     val ref: C#T => Rep[Int] = this.children(childClass)
-    ImmutableModelAccess(this.service.access[C](childClass, ModelFilter[C](ref(_) === model.id.get)))
+    ImmutableModelAccess(this.service.access[C](childClass, ModelFilter[C](ref(_) === model.id.value)))
   }
 
   /**

--- a/app/db/access/ModelAccess.scala
+++ b/app/db/access/ModelAccess.scala
@@ -66,7 +66,7 @@ class ModelAccess[M <: Model](val service: ModelService,
     * @param model Model to look for
     * @return True if contained in set
     */
-  def contains(model: M)(implicit ec: ExecutionContext): Future[Boolean] = this.service.count[M](this.modelClass, (this.baseFilter +&& IdFilter(model.id.get)).fn).map(_ > 0)
+  def contains(model: M)(implicit ec: ExecutionContext): Future[Boolean] = this.service.count[M](this.modelClass, (this.baseFilter +&& IdFilter(model.id.value)).fn).map(_ > 0)
 
   /**
     * Returns true if any models match the specified filter.

--- a/app/db/access/ModelAssociationAccess.scala
+++ b/app/db/access/ModelAssociationAccess.scala
@@ -15,7 +15,7 @@ class ModelAssociationAccess[Assoc <: AssociativeTable, M <: Model](service: Mod
   extends ModelAccess[M](service, childClass, ModelFilter[M] { child =>
     val assocQuery = for {
       row <- assoc.assocTable
-      if parentRef(row) === parent.id.get
+      if parentRef(row) === parent.id.value
     } yield childRef(row)
     val childrenIds: Seq[Int] = service.await(service.DB.db.run(assocQuery.result)).get
     child.id inSetBind childrenIds

--- a/app/db/dbObjects.scala
+++ b/app/db/dbObjects.scala
@@ -1,0 +1,48 @@
+package db
+
+import java.sql.Timestamp
+
+import db.ObjectId.Uninitialized
+
+sealed trait DbInitialized[A] {
+  def value: A
+  def unsafeToOption: Option[A]
+}
+
+sealed trait ObjectId extends DbInitialized[ObjectReference]
+object ObjectId {
+  case object Uninitialized extends ObjectId {
+    override def value: Nothing = sys.error("Tried to access uninitialized ObjectId")
+    override def unsafeToOption: Option[Nothing] = None
+  }
+
+  private case class RealObjectId(value: ObjectReference) extends ObjectId {
+    override def unsafeToOption: Option[ObjectReference] = Some(value)
+  }
+
+  def apply(id: ObjectReference): ObjectId = RealObjectId(id)
+
+  def unsafeFromOption(option: Option[ObjectReference]): ObjectId = option match {
+    case Some(id) => ObjectId(id)
+    case None => Uninitialized
+  }
+}
+
+sealed trait ObjectTimestamp extends DbInitialized[Timestamp]
+object ObjectTimestamp {
+  case object Uninitialized extends ObjectTimestamp {
+    override def value: Nothing = sys.error("Tried to access uninitialized ObjectTimestamp")
+    override def unsafeToOption: Option[Nothing] = None
+  }
+
+  private case class RealObjectTimestamp(value: Timestamp) extends ObjectTimestamp {
+    override def unsafeToOption: Option[Timestamp] = Some(value)
+  }
+
+  def apply(timestamp: Timestamp): ObjectTimestamp = RealObjectTimestamp(timestamp)
+
+  def unsafeFromOption(option: Option[Timestamp]): ObjectTimestamp = option match {
+    case Some(id) => ObjectTimestamp(id)
+    case None => Uninitialized
+  }
+}

--- a/app/db/impl/access/OrganizationBase.scala
+++ b/app/db/impl/access/OrganizationBase.scala
@@ -1,6 +1,6 @@
 package db.impl.access
 
-import db.{ModelBase, ModelService}
+import db.{ModelBase, ModelService, ObjectId}
 import discourse.OreDiscourseApi
 import models.user.role.OrganizationRole
 import models.user.{Notification, Organization}
@@ -59,8 +59,8 @@ class OrganizationBase(override val service: ModelService,
       // Next we will create the Organization on Ore itself. This contains a
       // reference to the Sponge user ID, the organization's username and a
       // reference to the User owner of the organization.
-      Logger.debug("Creating on Ore...")
-      this.add(Organization(id = Some(spongeUser.id), username = name, _ownerId = ownerId))
+      Logger.info("Creating on Ore...")
+      this.add(Organization(id = ObjectId(spongeUser.id), username = name, _ownerId = ownerId))
     }.semiFlatMap { org =>
       // Every organization model has a regular User companion. Organizations
       // are just normal users with additional information. Adding the
@@ -72,7 +72,7 @@ class OrganizationBase(override val service: ModelService,
         _ <- // Add the owner
           org.memberships.addRole(OrganizationRole(
             userId = ownerId,
-            organizationId = org.id.get,
+            organizationId = org.id.value,
             _roleType = RoleType.OrganizationOwner,
             _isAccepted = true))
         _ <- {
@@ -81,9 +81,9 @@ class OrganizationBase(override val service: ModelService,
 
           Future.sequence(members.map { role =>
             // TODO remove role.user db access we really only need the userid we already have for notifications
-            org.memberships.addRole(role.copy(organizationId = org.id.get)).flatMap(_ => role.user).flatMap { user =>
+            org.memberships.addRole(role.copy(organizationId = org.id.value)).flatMap(_ => role.user).flatMap { user =>
               user.sendNotification(Notification(
-                originId = org.id.get,
+                originId = org.id.value,
                 notificationType = NotificationTypes.OrganizationInvite,
                 messageArgs = List("notification.organization.invite", role.roleType.title, org.username)
               ))

--- a/app/db/impl/access/ProjectBase.scala
+++ b/app/db/impl/access/ProjectBase.scala
@@ -156,7 +156,7 @@ class ProjectBase(override val service: ModelService,
   def deleteChannel(channel: Channel)(implicit context: Project = null, ec: ExecutionContext): Future[Unit] = {
     for {
       project <- if (context != null) Future.successful(context) else channel.project
-      _ = checkArgument(project.id.get == channel.projectId, "invalid project id", "")
+      _ = checkArgument(project.id.value == channel.projectId, "invalid project id", "")
       channels <- project.channels.all
       noVersion <- channel.versions.isEmpty
       nonEmptyChannels <- Future.traverse(channels.toSeq)(_.versions.nonEmpty).map(_.count(identity))
@@ -181,7 +181,7 @@ class ProjectBase(override val service: ModelService,
       proj <- version.project
       size <- proj.versions.count(_.visibility === VisibilityTypes.Public)
       _ = checkArgument(size > 1, "only one public version", "")
-      _ = checkArgument(proj.id.get == version.projectId, "invalid context id", "")
+      _ = checkArgument(proj.id.value == version.projectId, "invalid context id", "")
       rv <- proj.recommendedVersion
       projects <- proj.versions.sorted(_.createdAt.desc) // TODO optimize: only query one version
       _ = {
@@ -232,7 +232,7 @@ class ProjectBase(override val service: ModelService,
       (pp, p)
     }
     val filtered = pagesQuery filter { case (pp, p) =>
-      pp.projectId === project.id && pp.parentId === -1
+      pp.projectId === project.id.unsafeToOption && pp.parentId === -1
     }
 
     service.DB.db.run(filtered.result).map(_.groupBy(_._1)) map { grouped => // group by parent page

--- a/app/db/impl/model/OreModel.scala
+++ b/app/db/impl/model/OreModel.scala
@@ -1,16 +1,14 @@
 package db.impl.model
 
-import java.sql.Timestamp
-
-import db.Model
+import db.{Model, ObjectId, ObjectTimestamp}
 import db.impl.access.{OrganizationBase, ProjectBase, UserBase}
 import discourse.OreDiscourseApi
 import ore.OreConfig
 import security.spauth.SpongeAuthApi
 
 /** An Ore Model */
-abstract class OreModel(override val id: Option[Int],
-                        override val createdAt: Option[Timestamp])
+abstract class OreModel(override val id: ObjectId,
+                        override val createdAt: ObjectTimestamp)
                        (implicit var userBase: UserBase = null,
                         var projectBase: ProjectBase = null,
                         var organizationBase: OrganizationBase = null,

--- a/app/db/impl/model/common/Hideable.scala
+++ b/app/db/impl/model/common/Hideable.scala
@@ -1,8 +1,5 @@
 package db.impl.model.common
 
-import java.sql.Timestamp
-import java.time.Instant
-
 import scala.concurrent.{ExecutionContext, Future}
 
 import db.Model
@@ -46,7 +43,7 @@ trait Hideable extends Model { self =>
     visibilityChanges.all.map(_.toSeq.sortWith(byCreationDate))
 
   def byCreationDate(first: ModelVisibilityChange, second: ModelVisibilityChange): Boolean =
-    first.createdAt.getOrElse(Timestamp.from(Instant.MIN)).getTime < second.createdAt.getOrElse(Timestamp.from(Instant.MIN)).getTime
+    first.createdAt.value.getTime < second.createdAt.value.getTime
 
   def lastVisibilityChange(implicit ec: ExecutionContext): OptionT[Future, ModelVisibilityChange] =
     OptionT(visibilityChanges.all.map(_.toSeq.filter(cr => !cr.isResolved).sortWith(byCreationDate).headOption))

--- a/app/db/impl/schema.scala
+++ b/app/db/impl/schema.scala
@@ -501,7 +501,10 @@ class LoggedActionTable(tag: RowTag) extends ModelTable[LoggedActionModel](tag, 
   def newState           =  column[String]("new_state")
   def oldState           =  column[String]("old_state")
 
-  override def * = (id.?, createdAt.?, userId, address, action, actionContext, actionContextId, newState, oldState) <> (LoggedActionModel.tupled, LoggedActionModel.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(LoggedActionModel.unapply)
+    (id.?, createdAt.?, userId, address, action, actionContext, actionContextId, newState, oldState) <> (convertApply(LoggedActionModel.apply _).tupled, convertedUnapply)
+  }
 }
 class VersionVisibilityChangeTable(tag: RowTag)
   extends ModelTable[VersionVisibilityChange](tag, "project_version_visibility_changes")
@@ -509,7 +512,10 @@ class VersionVisibilityChangeTable(tag: RowTag)
 
   def versionId = column[Int]("version_id")
 
-  override def * = (id.?, createdAt.?, createdBy.?, versionId, comment, resolvedAt.?, resolvedBy.?, visibility) <> (VersionVisibilityChange.tupled, VersionVisibilityChange.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(VersionVisibilityChange.unapply)
+    (id.?, createdAt.?, createdBy.?, versionId, comment, resolvedAt.?, resolvedBy.?, visibility) <> (convertApply(VersionVisibilityChange.apply _).tupled, convertedUnapply)
+  }
 }
 
 class LoggedActionViewTable(tag: RowTag) extends ModelTable[LoggedActionViewModel](tag, "v_logged_actions") {
@@ -539,9 +545,12 @@ class LoggedActionViewTable(tag: RowTag) extends ModelTable[LoggedActionViewMode
   def filterSubject      =   column[Int]("filter_subject")
   def filterAction       =   column[Int]("filter_action")
 
-  override def * = (id.?, createdAt.?, userId, address, action, actionContext, actionContextId, newState, oldState, uId,
-    uName, loggedProjectProjection, loggedProjectVersionProjection, loggedProjectPageProjection, loggedSubjectProjection,
-    filterProject.?, filterVersion.?, filterPage.?, filterSubject.?, filterAction.?) <> (LoggedActionViewModel.tupled, LoggedActionViewModel.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(LoggedActionViewModel.unapply)
+    (id.?, createdAt.?, userId, address, action, actionContext, actionContextId, newState, oldState, uId,
+      uName, loggedProjectProjection, loggedProjectVersionProjection, loggedProjectPageProjection, loggedSubjectProjection,
+      filterProject.?, filterVersion.?, filterPage.?, filterSubject.?, filterAction.?) <> (convertApply(LoggedActionViewModel.apply _).tupled, convertedUnapply)
+  }
 
   def loggedProjectProjection = (pId.?, pPluginId.?, pSlug.?, pOwnerName.?) <> ((LoggedProject.apply _).tupled, LoggedProject.unapply)
   def loggedProjectVersionProjection = (pvId.?, pvVersionString.?) <> ((LoggedProjectVersion.apply _).tupled, LoggedProjectVersion.unapply)

--- a/app/db/impl/schema.scala
+++ b/app/db/impl/schema.scala
@@ -3,6 +3,8 @@ package db.impl
 import java.sql.Timestamp
 
 import com.github.tminglei.slickpg.InetString
+
+import db.{ObjectId, ObjectTimestamp}
 import db.impl.OrePostgresDriver.api._
 import db.impl.schema._
 import db.impl.table.StatTable
@@ -24,6 +26,12 @@ import ore.rest.ProjectApiKeyTypes.ProjectApiKeyType
 import ore.user.Prompts.Prompt
 import ore.user.notification.NotificationTypes.NotificationType
 import play.api.i18n.Lang
+import shapeless._
+import nat._
+import syntax.std.function._
+import syntax.std.tuple._
+import ops.function._
+import ops.hlist._
 
 /*
  * Database schema definitions. Changes must be first applied as an evolutions
@@ -35,6 +43,40 @@ import play.api.i18n.Lang
 package object schema {
   type RowTag = slick.lifted.Tag
   type ProjectTag = models.project.Tag
+
+  def convertApply[F, Rest <: HList, R](f: F)(
+    implicit toHList: FnToProduct.Aux[F, ObjectId :: ObjectTimestamp :: Rest => R], 
+    fromHList: FnFromProduct[Option[Int] :: Option[Timestamp] :: Rest => R]
+  ): fromHList.Out = {
+    val objHListFun: ObjectId :: ObjectTimestamp :: Rest => R = toHList(f)
+    val optHListFun: Option[Int] :: Option[Timestamp] :: Rest => R = {
+      case id :: time :: rest => objHListFun(ObjectId.unsafeFromOption(id) :: ObjectTimestamp.unsafeFromOption(time) :: rest)
+    }
+    val normalFun: fromHList.Out = fromHList.apply(optHListFun)
+
+    normalFun
+  }
+
+  def convertUnapply[P <: Product, A, Repr <: HList, Rest <: HList](f: A => Option[P])(
+    implicit
+    fromTuple: Generic.Aux[P, Repr],
+    at0: At.Aux[Repr, _0, ObjectId],
+    at1: At.Aux[Repr, _1, ObjectTimestamp],
+    drop2: Drop.Aux[Repr, _2, Rest],
+    toTuple: Tupler[Option[Int] :: Option[Timestamp] :: Rest]
+  ): A => Option[toTuple.Out] = a => {
+    val optProd: Option[P] = f(a)
+    val mappedOptProd: Option[toTuple.Out] = optProd.map { prod =>
+      val repr: Repr = fromTuple.to(prod)
+      val id: ObjectId = at0(repr)
+      val time: ObjectTimestamp = at1(repr)
+      val rest: Rest = drop2(repr)
+      val newGen: Option[Int] :: Option[Timestamp] :: Rest = id.unsafeToOption :: time.unsafeToOption :: rest
+      toTuple(newGen)
+    }
+
+    mappedOptProd
+  }
 }
 
 trait ProjectTable extends ModelTable[Project]
@@ -57,9 +99,12 @@ trait ProjectTable extends ModelTable[Project]
   def lastUpdated           =   column[Timestamp]("last_updated")
   def notes                 =   column[String]("notes")
 
-  override def * = (id.?, createdAt.?, pluginId, ownerName, userId, name, slug, recommendedVersionId.?, category,
-                    description.?, stars, views, downloads, topicId, postId, isTopicDirty,
-                    visibility, lastUpdated, notes) <> ((Project.apply _).tupled, Project.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(Project.unapply)
+    (id.?, createdAt.?, pluginId, ownerName, userId, name, slug, recommendedVersionId.?, category,
+      description.?, stars, views, downloads, topicId, postId, isTopicDirty,
+      visibility, lastUpdated, notes) <> (convertApply(Project.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -77,8 +122,11 @@ class ProjectSettingsTable(tag: RowTag) extends ModelTable[ProjectSettings](tag,
   def licenseUrl            =   column[String]("license_url")
   def forumSync             =   column[Boolean]("forum_sync")
 
-  override def * = (id.?, createdAt.?, projectId, homepage.?, issues.?, source.?, licenseName.?,
-                    licenseUrl.?, forumSync) <> (ProjectSettings.tupled, ProjectSettings.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(ProjectSettings.unapply)
+    (id.?, createdAt.?, projectId, homepage.?, issues.?, source.?, licenseName.?,
+      licenseUrl.?, forumSync) <> (convertApply(ProjectSettings.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -94,8 +142,11 @@ class ProjectWatchersTable(tag: RowTag)
 
 class ProjectViewsTable(tag: RowTag) extends StatTable[ProjectView](tag, "project_views", "project_id") {
 
-  override def * = (id.?, createdAt.?, modelId, address, cookie,
-                    userId.?) <> ((ProjectView.apply _).tupled, ProjectView.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(ProjectView.unapply)
+    (id.?, createdAt.?, modelId, address, cookie,
+      userId.?) <> (convertApply(ProjectView.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -112,7 +163,10 @@ class ProjectLogTable(tag: RowTag) extends ModelTable[ProjectLog](tag, "project_
 
   def projectId = column[Int]("project_id")
 
-  override def * = (id.?, createdAt.?, projectId) <> (ProjectLog.tupled, ProjectLog.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(ProjectLog.unapply)
+    (id.?, createdAt.?, projectId) <> (convertApply(ProjectLog.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -124,8 +178,11 @@ class ProjectLogEntryTable(tg: RowTag) extends ModelTable[ProjectLogEntry](tg, "
   def occurrences = column[Int]("occurrences")
   def lastOccurrence = column[Timestamp]("last_occurrence")
 
-  override def * = (id.?, createdAt.?, logId, tag, message, occurrences, lastOccurrence) <> (ProjectLogEntry.tupled,
-                    ProjectLogEntry.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(ProjectLogEntry.unapply)
+    (id.?, createdAt.?, logId, tag, message, occurrences, lastOccurrence) <> (convertApply(ProjectLogEntry.apply _).tupled,
+      convertedUnapply)
+  }
 
 }
 
@@ -137,8 +194,11 @@ class PageTable(tag: RowTag) extends ModelTable[Page](tag, "project_pages") with
   def contents      =   column[String]("contents")
   def isDeletable   =   column[Boolean]("is_deletable")
 
-  override def * = (id.?, createdAt.?, projectId, parentId, name, slug, isDeletable,
-                    contents) <> ((Page.apply _).tupled, Page.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(Page.unapply)
+    (id.?, createdAt.?, projectId, parentId, name, slug, isDeletable,
+      contents) <> (convertApply(Page.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -148,8 +208,11 @@ class ChannelTable(tag: RowTag) extends ModelTable[Channel](tag, "project_channe
   def projectId     = column[Int]("project_id")
   def isNonReviewed = column[Boolean]("is_non_reviewed")
 
-  override def * = (id.?, createdAt.?, projectId, name, color, isNonReviewed) <> ((Channel.apply _).tupled,
-                    Channel.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(Channel.unapply)
+    (id.?, createdAt.?, projectId, name, color, isNonReviewed) <> (convertApply(Channel.apply _).tupled,
+      convertedUnapply)
+  }
 }
 
 class TagTable(tag: RowTag) extends ModelTable[ProjectTag](tag, "project_tags") with NameColumn[ProjectTag] {
@@ -158,7 +221,15 @@ class TagTable(tag: RowTag) extends ModelTable[ProjectTag](tag, "project_tags") 
   def data       = column[String]("data")
   def color      = column[TagColor]("color")
 
-  override def * = (id.?, versionIds, name, data, color) <> ((Tag.apply _).tupled, Tag.unapply)
+  override def * = {
+    val convertedApply: ((Option[Int], List[Int], String, String, TagColor)) => ProjectTag = {
+      case (id, versionIds, name, data, color) => Tag(ObjectId.unsafeFromOption(id), versionIds, name, data, color)
+    }
+    val convertedUnapply: PartialFunction[ProjectTag, (Option[Int], List[Int], String, String, TagColor)] = {
+      case Tag(id, versionIds, name, data, color) => (id.unsafeToOption, versionIds, name, data, color)
+    }
+    (id.?, versionIds, name, data, color) <> (convertedApply, convertedUnapply.lift)
+  }
 }
 
 class VersionTable(tag: RowTag) extends ModelTable[Version](tag, "project_versions")
@@ -182,9 +253,12 @@ class VersionTable(tag: RowTag) extends ModelTable[Version](tag, "project_versio
   def tagIds            =   column[List[Int]]("tags")
   def isNonReviewed     =   column[Boolean]("is_non_reviewed")
 
-  override def * = (id.?, createdAt.?, projectId, versionString, dependencies, assets.?, channelId,
-                    fileSize, hash, authorId, description.?, downloads, isReviewed, reviewerId, approvedAt.?,
-                    tagIds, visibility, fileName, signatureFileName, isNonReviewed) <> ((Version.apply _).tupled, Version.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(Version.unapply)
+    (id.?, createdAt.?, projectId, versionString, dependencies, assets.?, channelId,
+      fileSize, hash, authorId, description.?, downloads, isReviewed, reviewerId, approvedAt.?,
+      tagIds, visibility, fileName, signatureFileName, isNonReviewed) <> (convertApply(Version.apply _).tupled, convertedUnapply)
+  }
 }
 
 class DownloadWarningsTable(tag: RowTag) extends ModelTable[DownloadWarning](tag, "project_version_download_warnings") {
@@ -196,8 +270,11 @@ class DownloadWarningsTable(tag: RowTag) extends ModelTable[DownloadWarning](tag
   def downloadId = column[Int]("download_id")
   def isConfirmed = column[Boolean]("is_confirmed")
 
-  override def * = (id.?, createdAt.?, expiration, token, versionId, address, isConfirmed,
-                    downloadId) <> ((DownloadWarning.apply _).tupled, DownloadWarning.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(DownloadWarning.unapply)
+    (id.?, createdAt.?, expiration, token, versionId, address, isConfirmed,
+      downloadId) <> (convertApply(DownloadWarning.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -207,16 +284,22 @@ class UnsafeDownloadsTable(tag: RowTag) extends ModelTable[UnsafeDownload](tag, 
   def address = column[InetString]("address")
   def downloadType = column[DownloadType]("download_type")
 
-  override def * = (id.?, createdAt.?, userId.?, address, downloadType) <> (UnsafeDownload.tupled,
-                    UnsafeDownload.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(UnsafeDownload.unapply)
+    (id.?, createdAt.?, userId.?, address, downloadType) <> (convertApply(UnsafeDownload.apply _).tupled,
+      convertedUnapply)
+  }
 
 }
 
 class VersionDownloadsTable(tag: RowTag)
   extends StatTable[VersionDownload](tag, "project_version_downloads", "version_id") {
 
-  override def * = (id.?, createdAt.?, modelId, address, cookie, userId.?) <> ((VersionDownload.apply _).tupled,
-                    VersionDownload.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(VersionDownload.unapply)
+    (id.?, createdAt.?, modelId, address, cookie, userId.?) <> (convertApply(VersionDownload.apply _).tupled,
+      convertedUnapply)
+  }
 
 }
 
@@ -237,10 +320,12 @@ class UserTable(tag: RowTag) extends ModelTable[User](tag, "users") with NameCol
   def readPrompts           =   column[List[Prompt]]("read_prompts")
   def lang                  =   column[Lang]("language")
 
-  override def * = (id.?, createdAt.?, fullName.?, name, email.?, tagline.?, globalRoles, joinDate.?,
-                    avatarUrl.?, readPrompts, pgpPubKey.?, lastPgpPubKeyUpdate.?, isLocked, lang.?) <> ((User.apply _).tupled,
-                    User.unapply)
-
+  override def * = {
+    val convertedUnapply = convertUnapply(User.unapply)
+    (id.?, createdAt.?, fullName.?, name, email.?, tagline.?, globalRoles, joinDate.?,
+      avatarUrl.?, readPrompts, pgpPubKey.?, lastPgpPubKeyUpdate.?, isLocked, lang.?) <> (convertApply(User.apply _).tupled,
+      convertedUnapply)
+  }
 }
 
 class SessionTable(tag: RowTag) extends ModelTable[DbSession](tag, "user_sessions") {
@@ -249,7 +334,10 @@ class SessionTable(tag: RowTag) extends ModelTable[DbSession](tag, "user_session
   def username = column[String]("username")
   def token = column[String]("token")
 
-  def * = (id.?, createdAt.?, expiration, username, token) <> (DbSession.tupled, DbSession.unapply)
+  def * = {
+    val convertedUnapply = convertUnapply(DbSession.unapply)
+    (id.?, createdAt.?, expiration, username, token) <> (convertApply(DbSession.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -258,7 +346,10 @@ class SignOnTable(tag: RowTag) extends ModelTable[SignOn](tag, "user_sign_ons") 
   def nonce = column[String]("nonce")
   def isCompleted = column[Boolean]("is_completed")
 
-  def * = (id.?, createdAt.?, nonce, isCompleted) <> (SignOn.tupled, SignOn.unapply)
+  def * = {
+    val convertedUnapply = convertUnapply(SignOn.unapply)
+    (id.?, createdAt.?, nonce, isCompleted) <> (convertApply(SignOn.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -267,7 +358,10 @@ class OrganizationTable(tag: RowTag) extends ModelTable[Organization](tag, "orga
   override def id   =   column[Int]("id", O.PrimaryKey)
   def userId        =   column[Int]("user_id")
 
-  override def * = (id.?, createdAt.?, name, userId) <> ((Organization.apply _).tupled, Organization.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(Organization.unapply)
+    (id.?, createdAt.?, name, userId) <> (convertApply(Organization.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -295,8 +389,11 @@ class OrganizationRoleTable(tag: RowTag)
 
   def organizationId = column[Int]("organization_id")
 
-  override def * = (id.?, createdAt.?, userId, organizationId, roleType,
-                    isAccepted) <> (OrganizationRole.tupled, OrganizationRole.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(OrganizationRole.unapply)
+    (id.?, createdAt.?, userId, organizationId, roleType,
+      isAccepted) <> (convertApply(OrganizationRole.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -306,8 +403,11 @@ class ProjectRoleTable(tag: RowTag)
 
   def projectId = column[Int]("project_id")
 
-  override def * = (id.?, createdAt.?, userId, projectId, roleType, isAccepted) <> (ProjectRole.tupled,
-                    ProjectRole.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(ProjectRole.unapply)
+    (id.?, createdAt.?, userId, projectId, roleType, isAccepted) <> (convertApply(ProjectRole.apply _).tupled,
+      convertedUnapply)
+  }
 
 }
 
@@ -329,9 +429,11 @@ class NotificationTable(tag: RowTag) extends ModelTable[Notification](tag, "noti
   def action            =   column[String]("action")
   def read              =   column[Boolean]("read")
 
-  override def * = (id.?, createdAt.?, userId, originId, notificationType, messageArgs, action.?,
-                    read) <> (Notification.tupled, Notification.unapply)
-
+  override def * = {
+    val convertedUnapply = convertUnapply(Notification.unapply)
+    (id.?, createdAt.?, userId, originId, notificationType, messageArgs, action.?,
+      read) <> (convertApply(Notification.apply _).tupled, convertedUnapply)
+  }
 }
 
 class FlagTable(tag: RowTag) extends ModelTable[Flag](tag, "project_flags") {
@@ -344,7 +446,10 @@ class FlagTable(tag: RowTag) extends ModelTable[Flag](tag, "project_flags") {
   def resolvedAt  =   column[Timestamp]("resolved_at")
   def resolvedBy  =   column[Int]("resolved_by")
 
-  override def * = (id.?, createdAt.?, projectId, userId, reason, comment, isResolved, resolvedAt.?, resolvedBy.?) <> (Flag.tupled, Flag.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(Flag.unapply)
+    (id.?, createdAt.?, projectId, userId, reason, comment, isResolved, resolvedAt.?, resolvedBy.?) <> (convertApply(Flag.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -354,7 +459,10 @@ class ProjectApiKeyTable(tag: RowTag) extends ModelTable[ProjectApiKey](tag, "pr
   def keyType = column[ProjectApiKeyType]("key_type")
   def value = column[String]("value")
 
-  override def * = (id.?, createdAt.?, projectId, keyType, value) <> (ProjectApiKey.tupled, ProjectApiKey.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(ProjectApiKey.unapply)
+    (id.?, createdAt.?, projectId, keyType, value) <> (convertApply(ProjectApiKey.apply _).tupled, convertedUnapply)
+  }
 
 }
 
@@ -365,7 +473,10 @@ class ReviewTable(tag: RowTag) extends ModelTable[Review](tag, "project_version_
   def endedAt           =   column[Timestamp]("ended_at")
   def comment           =   column[String]("comment")
 
-  override def * =  (id.?, createdAt.?, versionId, userId, endedAt.?, comment) <> ((Review.apply _).tupled, Review.unapply)
+  override def * =  {
+    val convertedUnapply = convertUnapply(Review.unapply)
+    (id.?, createdAt.?, versionId, userId, endedAt.?, comment) <> (convertApply(Review.apply _).tupled, convertedUnapply)
+  }
 }
 
 class ProjectVisibilityChangeTable(tag: RowTag)
@@ -374,7 +485,10 @@ class ProjectVisibilityChangeTable(tag: RowTag)
 
   def projectId = column[Int]("project_id")
 
-  override def * = (id.?, createdAt.?, createdBy.?, projectId, comment, resolvedAt.?, resolvedBy.?, visibility) <> (ProjectVisibilityChange.tupled, ProjectVisibilityChange.unapply)
+  override def * = {
+    val convertedUnapply = convertUnapply(ProjectVisibilityChange.unapply)
+    (id.?, createdAt.?, createdBy.?, projectId, comment, resolvedAt.?, resolvedBy.?, visibility) <> (convertApply(ProjectVisibilityChange.apply _).tupled, convertedUnapply)
+  }
 }
 
 class LoggedActionTable(tag: RowTag) extends ModelTable[LoggedActionModel](tag, "logged_actions") {

--- a/app/db/impl/schema/StatSchema.scala
+++ b/app/db/impl/schema/StatSchema.scala
@@ -47,7 +47,7 @@ trait StatSchema[M <: StatEntry[_]] extends ModelSchema[M] {
   override def like(entry: M)(implicit ec: ExecutionContext): OptionT[Future, M] = {
     val baseFilter: ModelFilter[M] = ModelFilter[M](_.modelId === entry.modelId)
     val filter: M#T => Rep[Boolean] = e => e.address === entry.address || e.cookie === entry.cookie
-    val userFilter = entry.user.map[M#T => Rep[Boolean]](u => e => filter(e) || e.userId === u.id.get).getOrElse(filter)
+    val userFilter = entry.user.map[M#T => Rep[Boolean]](u => e => filter(e) || e.userId === u.id.value).getOrElse(filter)
     OptionT.liftF(userFilter).flatMap { uFilter =>
       this.service.find(this.modelClass, (baseFilter && uFilter).fn)
     }

--- a/app/db/package.scala
+++ b/app/db/package.scala
@@ -1,0 +1,5 @@
+package object db {
+
+  type ObjectReference = Int
+
+}

--- a/app/db/table/ModelAssociation.scala
+++ b/app/db/table/ModelAssociation.scala
@@ -36,7 +36,7 @@ class ModelAssociation[AssocTable <: AssociativeTable]
     */
   def assoc(model1: Model, model2: Model): Future[Int] = {
     val modelPair = orderModels(model1, model2)
-    this.service.DB.db.run(this.assocTable += (modelPair._1.id.get, modelPair._2.id.get))
+    this.service.DB.db.run(this.assocTable += (modelPair._1.id.value, modelPair._2.id.value))
   }
 
   /**
@@ -48,7 +48,7 @@ class ModelAssociation[AssocTable <: AssociativeTable]
   def disassoc(model1: Model, model2: Model): Future[Int] = {
     val modelPair = orderModels(model1, model2)
     this.service.DB.db.run {
-      this.assocTable.filter(t => ref1(t) === modelPair._1.id.get && ref2(t) === modelPair._2.id.get).delete
+      this.assocTable.filter(t => ref1(t) === modelPair._1.id.value && ref2(t) === modelPair._2.id.value).delete
     }
   }
 

--- a/app/discourse/OreDiscourseApi.scala
+++ b/app/discourse/OreDiscourseApi.scala
@@ -260,7 +260,7 @@ trait OreDiscourseApi extends DiscourseApi {
     if (!this.isEnabled)
       return Future.successful(true)
 
-    checkArgument(project.id.isDefined, "undefined project", "")
+    checkArgument(project.isDefined, "undefined project", "")
     checkArgument(project.topicId != -1, "undefined topic id", "")
 
     val resultPromise: Promise[Boolean] = Promise()

--- a/app/discourse/OreDiscourseApi.scala
+++ b/app/discourse/OreDiscourseApi.scala
@@ -74,7 +74,7 @@ trait OreDiscourseApi extends DiscourseApi {
   def createProjectTopic(project: Project)(implicit ec: ExecutionContext): Future[Boolean] = {
     if (!this.isEnabled)
       return Future.successful(true)
-    checkArgument(project.id.isDefined, "undefined project", "")
+    checkArgument(project.isDefined, "undefined project", "")
     val content = this.templates.projectTopic(project)
     val title = this.templates.projectTitle(project)
     val resultPromise: Promise[Boolean] = Promise()
@@ -133,7 +133,7 @@ trait OreDiscourseApi extends DiscourseApi {
   def updateProjectTopic(project: Project)(implicit ec: ExecutionContext): Future[Boolean] = {
     if (!this.isEnabled)
       return Future.successful(true)
-    checkArgument(project.id.isDefined, "undefined project", "")
+    checkArgument(project.isDefined, "undefined project", "")
     checkArgument(project.topicId != -1, "undefined topic id", "")
     checkArgument(project.postId != -1, "undefined post id", "")
 
@@ -240,9 +240,9 @@ trait OreDiscourseApi extends DiscourseApi {
   def postVersionRelease(project: Project, version: Version, content: Option[String])(implicit ec: ExecutionContext): Future[List[String]] = {
     if (!this.isEnabled)
       return Future.successful(List.empty)
-    checkArgument(project.id.isDefined, "undefined project", "")
-    checkArgument(version.id.isDefined, "undefined version", "")
-    checkArgument(version.projectId == project.id.get, "invalid version project pair", "")
+    checkArgument(project.isDefined, "undefined project", "")
+    checkArgument(version.isDefined, "undefined version", "")
+    checkArgument(version.projectId == project.id.value, "invalid version project pair", "")
     project.owner.user.flatMap { user =>
       postDiscussionReply(
         project,
@@ -286,7 +286,7 @@ trait OreDiscourseApi extends DiscourseApi {
   def deleteProjectTopic(project: Project)(implicit ec: ExecutionContext): Future[Boolean] = {
     if (!this.isEnabled)
       return Future.successful(true)
-    checkArgument(project.id.isDefined, "undefined project", "")
+    checkArgument(project.isDefined, "undefined project", "")
     checkArgument(project.topicId != -1, "undefined topic id", "")
 
     def logFailure(): Unit = Logger.warn(s"Couldn't delete topic for project: ${project.url}. Rescheduling...")

--- a/app/form/OreForms.scala
+++ b/app/form/OreForms.scala
@@ -234,7 +234,7 @@ class OreForms @Inject()(implicit config: OreConfig, factory: ProjectFactory, se
         .toRight(required(key))
     }
 
-    def unbind(key: String, value: ProjectApiKey): Map[String, String] = Map(key -> value.id.get.toString)
+    def unbind(key: String, value: ProjectApiKey): Map[String, String] = Map(key -> value.id.value.toString)
   })
 
   def evilAwaitpProjectApiKey(key: Int)(implicit ec: ExecutionContext): Option[ProjectApiKey] = {

--- a/app/form/organization/OrganizationMembersUpdate.scala
+++ b/app/form/organization/OrganizationMembersUpdate.scala
@@ -44,7 +44,7 @@ case class OrganizationMembersUpdate(override val users: List[Int],
 
       type RoleType = OrganizationRole
     } = organization.memberships
-    val orgId = organization.id.get
+    val orgId = organization.id.value
     for (role <- this.build()) {
       val user = role.user
       dossier.addRole(role.copy(organizationId = orgId))

--- a/app/models/admin/LoggedActionView.scala
+++ b/app/models/admin/LoggedActionView.scala
@@ -1,8 +1,8 @@
 package models.admin
 
-import java.sql.Timestamp
-
 import com.github.tminglei.slickpg.InetString
+
+import db.{ObjectId, ObjectTimestamp}
 import db.impl.{LoggedActionTable, LoggedActionViewTable}
 import db.impl.model.OreModel
 import models.user.{LoggedAction, LoggedActionContext}
@@ -13,8 +13,8 @@ case class LoggedProjectVersion(pvId: Option[Int], pvVersionString: Option[Strin
 case class LoggedProjectPage(ppId: Option[Int], ppSlug: Option[String])
 case class LoggedSubject(sId: Option[Int], sName: Option[String])
 
-case class LoggedActionViewModel(override val id: Option[Int] = None,
-                             override val createdAt: Option[Timestamp] = None,
+case class LoggedActionViewModel(override val id: ObjectId = ObjectId.Uninitialized,
+                             override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                              private val _userId: Int,
                              private val _address: InetString,
                              private val _action: LoggedAction,
@@ -37,7 +37,7 @@ case class LoggedActionViewModel(override val id: Option[Int] = None,
   override type T = LoggedActionViewTable
   override type M = LoggedActionViewModel
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): LoggedActionViewModel = this.copy(createdAt = theTime)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): LoggedActionViewModel = this.copy(createdAt = theTime)
   override def userId: Int = _userId
 
   def address: InetString = _address

--- a/app/models/admin/ProjectLogEntry.scala
+++ b/app/models/admin/ProjectLogEntry.scala
@@ -4,6 +4,7 @@ import java.sql.Timestamp
 
 import scala.concurrent.Future
 
+import db.{ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.ProjectLogEntryTable
 import db.impl.model.OreModel
 import db.impl.table.ModelKeys._
@@ -19,9 +20,9 @@ import db.impl.table.ModelKeys._
   * @param _occurrences     Amount of occurrences
   * @param _lastOccurrence  Instant of last occurrence
   */
-case class ProjectLogEntry(override val id: Option[Int] = None,
-                           override val createdAt: Option[Timestamp] = None,
-                           logId: Int,
+case class ProjectLogEntry(override val id: ObjectId = ObjectId.Uninitialized,
+                           override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                           logId: ObjectReference,
                            tag: String,
                            message: String,
                            private var _occurrences: Int = 1,
@@ -65,6 +66,5 @@ case class ProjectLogEntry(override val id: Option[Int] = None,
     update(LastOccurrence)
   }
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): ProjectLogEntry = this.copy(id = id, createdAt = theTime)
-
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): ProjectLogEntry = this.copy(id = id, createdAt = theTime)
 }

--- a/app/models/admin/ProjectVisibilityChange.scala
+++ b/app/models/admin/ProjectVisibilityChange.scala
@@ -2,7 +2,7 @@ package models.admin
 
 import java.sql.Timestamp
 
-import db.Model
+import db.{Model, ObjectId, ObjectTimestamp}
 import db.impl.model.OreModel
 import db.impl.table.ModelKeys._
 import models.project.Page
@@ -15,8 +15,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import db.impl.ProjectVisibilityChangeTable
 import db.impl.model.common.VisibilityChange
 
-case class ProjectVisibilityChange(override val id: Option[Int] = None,
-                            override val createdAt: Option[Timestamp] = None,
+case class ProjectVisibilityChange(override val id: ObjectId = ObjectId.Uninitialized,
+                            override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                             createdBy: Option[Int] = None,
                             projectId: Int = -1,
                             comment: String,
@@ -47,7 +47,7 @@ case class ProjectVisibilityChange(override val id: Option[Int] = None,
     * Set the resolvedBy user
     */
   def setResolvedBy(user: User): Future[Int] = {
-    this.resolvedBy = user.id
+    this.resolvedBy = Some(user.id.value)
     update(ResolvedByVC)
   }
   def setResolvedById(userId: Int): Future[Int] = {
@@ -62,5 +62,5 @@ case class ProjectVisibilityChange(override val id: Option[Int] = None,
     * @param theTime Timestamp
     * @return Copy of model
     */
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Model = this.copy(id = id, createdAt = createdAt)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Model = this.copy(id = id, createdAt = createdAt)
 }

--- a/app/models/admin/Review.scala
+++ b/app/models/admin/Review.scala
@@ -144,11 +144,11 @@ case class Message(message: String, time: Long = System.currentTimeMillis(), act
 object Review {
   def ordering: Ordering[(Review, _)] = {
     // TODO make simple + check order
-    Ordering.by(_._1.createdAt.unsafeToOption.getOrElse(Timestamp.from(Instant.MIN)).getTime)
+    Ordering.by(_._1.createdAt.value.getTime)
   }
 
   def ordering2: Ordering[Review] = {
     // TODO make simple + check order
-    Ordering.by(_.createdAt.unsafeToOption.getOrElse(Timestamp.from(Instant.MIN)).getTime)
+    Ordering.by(_.createdAt.value.getTime)
   }
 }

--- a/app/models/admin/Review.scala
+++ b/app/models/admin/Review.scala
@@ -3,7 +3,7 @@ package models.admin
 import java.sql.Timestamp
 import java.time.Instant
 
-import db.Model
+import db.{Model, ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.ReviewTable
 import db.impl.model.OreModel
 import db.impl.schema.ReviewSchema
@@ -29,10 +29,10 @@ import play.api.i18n.Messages
   * @param endedAt      When the approval process ended
   * @param message      Message of why it ended
   */
-case class Review(override val id: Option[Int] = None,
-                  override val createdAt: Option[Timestamp] = None,
-                  versionId: Int = -1,
-                  userId: Int,
+case class Review(override val id: ObjectId = ObjectId.Uninitialized,
+                  override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                  versionId: ObjectReference = -1,
+                  userId: ObjectReference,
                   var endedAt: Option[Timestamp],
                   var message: String) extends OreModel(id, createdAt) {
 
@@ -114,7 +114,7 @@ case class Review(override val id: Option[Int] = None,
     * @param theTime Timestamp
     * @return Copy of model
     */
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Model = this.copy(id = id, createdAt = createdAt)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Model = this.copy(id = id, createdAt = createdAt)
 
   /**
     * Helper function to decode the json
@@ -144,11 +144,11 @@ case class Message(message: String, time: Long = System.currentTimeMillis(), act
 object Review {
   def ordering: Ordering[(Review, _)] = {
     // TODO make simple + check order
-    Ordering.by(_._1.createdAt.getOrElse(Timestamp.from(Instant.MIN)).getTime)
+    Ordering.by(_._1.createdAt.unsafeToOption.getOrElse(Timestamp.from(Instant.MIN)).getTime)
   }
 
   def ordering2: Ordering[Review] = {
     // TODO make simple + check order
-    Ordering.by(_.createdAt.getOrElse(Timestamp.from(Instant.MIN)).getTime)
+    Ordering.by(_.createdAt.unsafeToOption.getOrElse(Timestamp.from(Instant.MIN)).getTime)
   }
 }

--- a/app/models/admin/VersionVisibilityChange.scala
+++ b/app/models/admin/VersionVisibilityChange.scala
@@ -4,7 +4,7 @@ import java.sql.Timestamp
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import db.Model
+import db.{Model, ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.VersionVisibilityChangeTable
 import db.impl.model.OreModel
 import db.impl.model.common.VisibilityChange
@@ -15,10 +15,10 @@ import play.twirl.api.Html
 import util.functional.OptionT
 import util.instances.future._
 
-case class VersionVisibilityChange(override val id: Option[Int] = None,
-                            override val createdAt: Option[Timestamp] = None,
-                            createdBy: Option[Int] = None,
-                            projectId: Int = -1,
+case class VersionVisibilityChange(override val id: ObjectId = ObjectId.Uninitialized,
+                            override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                            createdBy: Option[ObjectReference] = None,
+                            projectId: ObjectReference = -1,
                             comment: String,
                             var resolvedAt: Option[Timestamp] = None,
                             var resolvedBy: Option[Int] = None,
@@ -48,10 +48,7 @@ case class VersionVisibilityChange(override val id: Option[Int] = None,
     * Set the resolvedBy user
     * @param user
     */
-  def setResolvedBy(user: User): Future[Int] = {
-    this.resolvedBy = user.id
-    update(ResolvedByVC)
-  }
+  def setResolvedBy(user: User): Future[Int] = setResolvedById(user.id.value)
   def setResolvedById(userId: Int): Future[Int] = {
     this.resolvedBy = Some(userId)
     update(ResolvedByVC)
@@ -64,5 +61,5 @@ case class VersionVisibilityChange(override val id: Option[Int] = None,
     * @param theTime Timestamp
     * @return Copy of model
     */
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Model = this.copy(id = id, createdAt = createdAt)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Model = this.copy(id = id, createdAt = createdAt)
 }

--- a/app/models/api/ProjectApiKey.scala
+++ b/app/models/api/ProjectApiKey.scala
@@ -1,15 +1,14 @@
 package models.api
 
-import java.sql.Timestamp
-
+import db.{ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.ProjectApiKeyTable
 import db.impl.model.OreModel
 import ore.project.ProjectOwned
 import ore.rest.ProjectApiKeyTypes.ProjectApiKeyType
 
-case class ProjectApiKey(override val id: Option[Int] = None,
-                         override val createdAt: Option[Timestamp] = None,
-                         override val projectId: Int,
+case class ProjectApiKey(override val id: ObjectId = ObjectId.Uninitialized,
+                         override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                         override val projectId: ObjectReference,
                          keyType: ProjectApiKeyType,
                          value: String)
                          extends OreModel(id, createdAt) with ProjectOwned {
@@ -17,6 +16,5 @@ case class ProjectApiKey(override val id: Option[Int] = None,
   override type T = ProjectApiKeyTable
   override type M = ProjectApiKey
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): ProjectApiKey = this.copy(id = id, createdAt = theTime)
-
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): ProjectApiKey = this.copy(id = id, createdAt = theTime)
 }

--- a/app/models/project/Channel.scala
+++ b/app/models/project/Channel.scala
@@ -1,13 +1,11 @@
 package models.project
 
-import java.sql.Timestamp
-
 import scala.concurrent.Future
 
 import com.google.common.base.Preconditions._
 
-import db.Named
 import db.access.ModelAccess
+import db.{Named, ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.ChannelTable
 import db.impl.model.OreModel
 import db.impl.table.ModelKeys
@@ -27,9 +25,9 @@ import ore.permission.scope.ProjectScope
   * @param _color       Color used to represent this Channel
   * @param projectId    ID of project this channel belongs to
   */
-case class Channel(override val id: Option[Int] = None,
-                   override val createdAt: Option[Timestamp] = None,
-                   override val projectId: Int,
+case class Channel(override val id: ObjectId = ObjectId.Uninitialized,
+                   override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                   override val projectId: ObjectReference,
                    private var _name: String,
                    private var _color: Color,
                    private var _isNonReviewed: Boolean = false)
@@ -41,7 +39,7 @@ case class Channel(override val id: Option[Int] = None,
   override type T = ChannelTable
   override type M = Channel
 
-  def this(name: String, color: Color, projectId: Int) = this(_name=name, _color=color, projectId=projectId)
+  def this(name: String, color: Color, projectId: ObjectReference) = this(_name=name, _color=color, projectId=projectId)
 
   /**
     * Returns the name of this Channel.
@@ -98,11 +96,10 @@ case class Channel(override val id: Option[Int] = None,
     */
   def versions: ModelAccess[Version] = this.schema.getChildren[Version](classOf[Version], this)
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Channel = this.copy(id = id, createdAt = theTime)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Channel = this.copy(id = id, createdAt = theTime)
   override def compare(that: Channel): Int = this._name compare that._name
-  override def hashCode(): Int = this.id.get.hashCode
-  override def equals(o: Any): Boolean = o.isInstanceOf[Channel] && o.asInstanceOf[Channel].id.get == this.id.get
-
+  override def hashCode(): Int = this.id.value.hashCode
+  override def equals(o: Any): Boolean = o.isInstanceOf[Channel] && o.asInstanceOf[Channel].id.value == this.id.value
 }
 
 object Channel {

--- a/app/models/project/DownloadWarning.scala
+++ b/app/models/project/DownloadWarning.scala
@@ -5,7 +5,7 @@ import java.sql.Timestamp
 import com.github.tminglei.slickpg.InetString
 import com.google.common.base.Preconditions._
 import controllers.sugar.Bakery
-import db.Expirable
+import db.{Expirable, ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.DownloadWarningsTable
 import db.impl.model.OreModel
 import db.impl.table.ModelKeys._
@@ -28,14 +28,14 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param address      Address of client who landed on the warning
   * @param _downloadId  Download ID
   */
-case class DownloadWarning(override val id: Option[Int] = None,
-                           override val createdAt: Option[Timestamp] = None,
+case class DownloadWarning(override val id: ObjectId = ObjectId.Uninitialized,
+                           override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                            override val expiration: Timestamp,
                            token: String,
-                           versionId: Int,
+                           versionId: ObjectReference,
                            address: InetString,
                            private var _isConfirmed: Boolean = false,
-                           private var _downloadId: Int = -1) extends OreModel(id, createdAt) with Expirable {
+                           private var _downloadId: ObjectReference = -1) extends OreModel(id, createdAt) with Expirable {
 
   override type M = DownloadWarning
   override type T = DownloadWarningsTable
@@ -52,7 +52,7 @@ case class DownloadWarning(override val id: Option[Int] = None,
     *
     * @return Download ID
     */
-  def downloadId: Int = this._downloadId
+  def downloadId: ObjectReference = this._downloadId
 
   /**
     * Returns the download this warning was for.
@@ -74,7 +74,7 @@ case class DownloadWarning(override val id: Option[Int] = None,
   def setDownload(download: UnsafeDownload): Future[Int] = Defined {
     checkNotNull(download, "null download", "")
     checkArgument(download.isDefined, "undefined download", "")
-    this._downloadId = download.id.get
+    this._downloadId = download.id.value
     update(DownloadId)
   }
 
@@ -88,8 +88,7 @@ case class DownloadWarning(override val id: Option[Int] = None,
     bakery.bake(COOKIE, this.token)
   }
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): DownloadWarning = this.copy(id = id, createdAt = theTime)
-
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): DownloadWarning = this.copy(id = id, createdAt = theTime)
 }
 
 object DownloadWarning {

--- a/app/models/project/Page.scala
+++ b/app/models/project/Page.scala
@@ -1,7 +1,6 @@
 package models.project
 
 import java.net.{URI, URISyntaxException}
-import java.sql.Timestamp
 
 import com.google.common.base.Preconditions._
 import com.vladsch.flexmark.ast.{MailLink, Node}
@@ -22,7 +21,7 @@ import db.impl.PageTable
 import db.impl.model.OreModel
 import db.impl.schema.PageSchema
 import db.impl.table.ModelKeys._
-import db.{ModelFilter, Named}
+import db.{ModelFilter, Named, ObjectId, ObjectReference, ObjectTimestamp}
 import ore.OreConfig
 import ore.permission.scope.ProjectScope
 import play.twirl.api.Html
@@ -44,10 +43,10 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param _contents    Markdown contents
   * @param isDeletable  True if can be deleted by the user
   */
-case class Page(override val id: Option[Int] = None,
-                override val createdAt: Option[Timestamp] = None,
-                override val projectId: Int = -1,
-                parentId: Int = -1,
+case class Page(override val id: ObjectId = ObjectId.Uninitialized,
+                override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                override val projectId: ObjectReference = -1,
+                parentId: ObjectReference = -1,
                 override val name: String,
                 slug: String,
                 isDeletable: Boolean = true,
@@ -144,11 +143,11 @@ case class Page(override val id: Option[Int] = None,
     * @return Page's children
     */
   def children: ModelAccess[Page]
-  = this.service.access[Page](classOf[Page], ModelFilter[Page](_.parentId === this.id.get))
+  = this.service.access[Page](classOf[Page], ModelFilter[Page](_.parentId === this.id.value))
 
   def url(implicit project: Project, parentPage: Option[Page]) : String = project.url + "/pages/" + this.fullSlug(parentPage)
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Page = this.copy(id = id, createdAt = theTime)
 
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Page = this.copy(id = id, createdAt = theTime)
 }
 
 object Page {

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -37,6 +37,7 @@ import slick.lifted
 import slick.lifted.{Rep, TableQuery}
 import scala.concurrent.{ExecutionContext, Future}
 
+import models.admin.{ProjectLog, ProjectVisibilityChange}
 import play.api.i18n.Messages
 
 /**

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -17,8 +17,7 @@ import db.impl.model.common.{Describable, Downloadable, Hideable, VisibilityChan
 import db.impl.schema.ProjectSchema
 import db.impl.table.ModelKeys
 import db.impl.table.ModelKeys._
-import db.{ModelService, Named}
-import models.admin.{ProjectLog, ProjectVisibilityChange}
+import db.{ModelService, Named, ObjectId, ObjectReference, ObjectTimestamp}
 import models.api.ProjectApiKey
 import models.project.VisibilityTypes.{Public, Visibility}
 import models.statistic.ProjectView
@@ -63,21 +62,21 @@ import play.api.i18n.Messages
   * @param _lastUpdated           Instant of last version release
   * @param _notes                 JSON notes
   */
-case class Project(override val id: Option[Int] = None,
-                   override val createdAt: Option[Timestamp] = None,
+case class Project(override val id: ObjectId = ObjectId.Uninitialized,
+                   override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                    pluginId: String,
                    private var _ownerName: String,
-                   private var _ownerId: Int,
+                   private var _ownerId: ObjectReference,
                    private var _name: String,
                    private var _slug: String,
-                   var recommendedVersionId: Option[Int] = None,
+                   var recommendedVersionId: Option[ObjectReference] = None,
                    private var _category: Category = Categories.Undefined,
                    private var _description: Option[String] = None,
                    private var _stars: Int = 0,
                    private var _views: Int = 0,
                    private var _downloads: Int = 0,
-                   private var _topicId: Int = -1,
-                   private var _postId: Int = -1,
+                   private var _topicId: ObjectReference = -1,
+                   private var _postId: ObjectReference = -1,
                    private var _isTopicDirty: Boolean = false,
                    private var _visibility: Visibility = Public,
                    private var _lastUpdated: Timestamp = null,
@@ -126,7 +125,7 @@ case class Project(override val id: Option[Int] = None,
     val roleClass: Class[RoleType] = classOf[ProjectRole]
     val model: ModelType = Project.this
 
-    def newMember(userId: Int)(implicit ec: ExecutionContext): MemberType = new ProjectMember(this.model, userId)
+    def newMember(userId: ObjectReference)(implicit ec: ExecutionContext): MemberType = new ProjectMember(this.model, userId)
 
 
     /**
@@ -136,28 +135,28 @@ case class Project(override val id: Option[Int] = None,
       * @return Trust of user
       */
     override def getTrust(user: User)(implicit ex: ExecutionContext): Future[Trust] = {
-      this.userBase.service.DB.db.run(Project.roleForTrustQuery(id.get, user.id.get).result).map { l =>
+      this.userBase.service.DB.db.run(Project.roleForTrustQuery(id.value, user.id.value).result).map { l =>
         val ordering: Ordering[ProjectRole] = Ordering.by(m => m.roleType.trust)
         l.sorted(ordering).headOption.map(_.roleType.trust).getOrElse(Default)
       }
     }
 
-    def clearRoles(user: User): Future[Int] = this.roleAccess.removeAll({ s => (s.userId === user.id.get) && (s.projectId === id.get) })
+    def clearRoles(user: User): Future[Int] = this.roleAccess.removeAll({ s => (s.userId === user.id.value) && (s.projectId === id.value) })
 
   }
 
-  def this(pluginId: String, name: String, owner: String, ownerId: Int) = {
+  def this(pluginId: String, name: String, owner: String, ownerId: ObjectReference) = {
     this(pluginId=pluginId, _name=compact(name), _slug=slugify(name), _ownerName=owner, _ownerId=ownerId)
   }
 
-  def isOwner(user: User) : Boolean = user.id.contains(_ownerId)
+  def isOwner(user: User) : Boolean = user.id.value == _ownerId
 
   /**
     * Returns the ID of the [[User]] that owns this Project.
     *
     * @return ID of user
     */
-  def ownerId: Int = this._ownerId
+  def ownerId: ObjectReference = this._ownerId
 
   /**
     * Returns the name of the [[User]] that owns this Project.
@@ -199,7 +198,7 @@ case class Project(override val id: Option[Int] = None,
   def setOwner(user: User): Future[Int] = {
     checkNotNull(user, "null user", "")
     checkArgument(user.isDefined, "undefined user", "")
-    this._ownerId = user.id.get
+    this._ownerId = user.id.value
     this._ownerName = user.name
     if (isDefined) {
       update(OwnerId)
@@ -302,7 +301,7 @@ case class Project(override val id: Option[Int] = None,
     * @return Project settings
     */
   def settings(implicit ec: ExecutionContext): Future[ProjectSettings]
-  = this.service.access[ProjectSettings](classOf[ProjectSettings]).find(_.projectId === this.id.get).getOrElse(throw new NoSuchElementException("Get on None"))
+  = this.service.access[ProjectSettings](classOf[ProjectSettings]).find(_.projectId === this.id.value).getOrElse(throw new NoSuchElementException("Get on None"))
 
   /**
     * Sets this [[Project]]'s [[ProjectSettings]].
@@ -313,7 +312,7 @@ case class Project(override val id: Option[Int] = None,
   def updateSettings(settings: ProjectSettings)(implicit ec: ExecutionContext): Future[ProjectSettings] = Defined {
     checkNotNull(settings, "null settings", "")
     val access = this.service.access[ProjectSettings](classOf[ProjectSettings])
-    val id = this.id.get
+    val id = this.id.value
     for {
       // Delete previous settings
       _ <- access.removeAll(_.projectId === id)
@@ -345,7 +344,7 @@ case class Project(override val id: Option[Int] = None,
         0
     }
     cnt.flatMap { _ =>
-      val change = ProjectVisibilityChange(None, Some(Timestamp.from(Instant.now())), Some(creator), this.id.get, comment, None, None, visibility.id)
+      val change = ProjectVisibilityChange(ObjectId.Uninitialized, ObjectTimestamp(Timestamp.from(Instant.now())), Some(creator), this.id.value, comment, None, None, visibility.id)
       this.service.access[ProjectVisibilityChange](classOf[ProjectVisibilityChange]).add(change)
     }
   }
@@ -464,9 +463,9 @@ case class Project(override val id: Option[Int] = None,
     checkNotNull(user, "null user", "")
     checkNotNull(reason, "null reason", "")
     checkArgument(user.isDefined, "undefined user", "")
-    val userId = user.id.get
+    val userId = user.id.value
     checkArgument(userId != this.ownerId, "cannot flag own project", "")
-    this.service.access[Flag](classOf[Flag]).add(new Flag(this.id.get, user.id.get, reason, comment))
+    this.service.access[Flag](classOf[Flag]).add(new Flag(this.id.value, userId, reason, comment))
   }
 
   /**
@@ -500,7 +499,7 @@ case class Project(override val id: Option[Int] = None,
   def setRecommendedVersion(_version: Version): Future[AnyVal] = {
     checkNotNull(_version, "null version", "")
     checkArgument(_version.isDefined, "undefined version", "")
-    this.recommendedVersionId = _version.id
+    this.recommendedVersionId = Some(_version.id.value)
     if (isDefined) update(RecommendedVersionId) else Future.unit
   }
 
@@ -545,7 +544,7 @@ case class Project(override val id: Option[Int] = None,
     * @return Project home page
     */
   def homePage(implicit ec: ExecutionContext): Page = Defined {
-    val page = new Page(this.id.get, Page.HomeName, Page.Template(this.name, Page.HomeMessage), false, -1)
+    val page = new Page(this.id.value, Page.HomeName, Page.Template(this.name, Page.HomeMessage), false, -1)
     this.service.await(page.schema.getOrInsert(page)).get
   }
 
@@ -572,7 +571,7 @@ case class Project(override val id: Option[Int] = None,
         checkArgument(text.length <= Page.MaxLengthPage, "contents too long", "")
         text
     }
-    val page = new Page(this.id.get, name, c, true, parentId)
+    val page = new Page(this.id.value, name, c, true, parentId)
     page.schema.getOrInsert(page)
   }
 
@@ -582,12 +581,12 @@ case class Project(override val id: Option[Int] = None,
     * @return Root pages of project
     */
   def rootPages(implicit ec: ExecutionContext): Future[Seq[Page]] = {
-    this.service.access[Page](classOf[Page]).sorted(_.name, p => p.projectId === this.id.get && p.parentId === -1)
+    this.service.access[Page](classOf[Page]).sorted(_.name, p => p.projectId === this.id.value && p.parentId === -1)
   }
 
   def logger(implicit ec: ExecutionContext): Future[ProjectLog] = {
     val loggers = this.service.access[ProjectLog](classOf[ProjectLog])
-    loggers.find(_.projectId === this.id.get).getOrElseF(loggers.add(ProjectLog(projectId = this.id.get)))
+    loggers.find(_.projectId === this.id.value).getOrElseF(loggers.add(ProjectLog(projectId = this.id.value)))
   }
 
   /**
@@ -602,7 +601,7 @@ case class Project(override val id: Option[Int] = None,
     *
     * @param _topicId ID to set
     */
-  def setTopicId(_topicId: Int): Future[Int] = Defined {
+  def setTopicId(_topicId: ObjectReference): Future[Int] = Defined {
     this._topicId = _topicId
     update(TopicId)
   }
@@ -619,7 +618,7 @@ case class Project(override val id: Option[Int] = None,
     *
     * @param _postId Forum post ID
     */
-  def setPostId(_postId: Int): Future[Int] = Defined {
+  def setPostId(_postId: ObjectReference): Future[Int] = Defined {
     this._postId = _postId
     update(PostId)
   }
@@ -644,11 +643,11 @@ case class Project(override val id: Option[Int] = None,
 
   def apiKeys: ModelAccess[ProjectApiKey] = this.schema.getChildren[ProjectApiKey](classOf[ProjectApiKey], this)
 
-  override def projectId: Int = Defined(this.id.get)
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Project
-  = this.copy(id = id, createdAt = theTime, _lastUpdated = theTime.orNull)
-  override def hashCode(): Int = this.id.get.hashCode
-  override def equals(o: Any): Boolean = o.isInstanceOf[Project] && o.asInstanceOf[Project].id.get == this.id.get
+  override def projectId: ObjectReference = Defined(this.id.value)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Project =
+    this.copy(id = id, createdAt = theTime, _lastUpdated = theTime.value)
+  override def hashCode(): Int = this.id.value.hashCode
+  override def equals(o: Any): Boolean = o.isInstanceOf[Project] && o.asInstanceOf[Project].id.value == this.id.value
 
   /**
     * Set a message and update the database
@@ -749,7 +748,7 @@ object Project {
 
     private var _pluginId: String = _
     private var _ownerName: String = _
-    private var _ownerId: Int = -1
+    private var _ownerId: ObjectReference = -1
     private var _name: String = _
     private var _visibility: Visibility = _
 
@@ -763,7 +762,7 @@ object Project {
       this
     }
 
-    def ownerId(ownerId: Int): Builder = {
+    def ownerId(ownerId: ObjectReference): Builder = {
       this._ownerId = ownerId
       this
     }

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -510,7 +510,7 @@ case class Project(override val id: ObjectId = ObjectId.Uninitialized,
   def tags(implicit ec: ExecutionContext, service: ModelService): Future[Seq[Tag]] = {
     schema(service)
     // get all the versions for the project
-    this.service.access(classOf[Version]).filter(_.projectId === id.get).flatMap { versions =>
+    this.service.access(classOf[Version]).filter(_.projectId === id.value).flatMap { versions =>
       val tagIds = versions.flatMap(_.tagIds).distinct
       // get all the tags for all the versions
       this.service.access(classOf[Tag]).filter(t => t.id inSet tagIds).map { list =>
@@ -520,10 +520,10 @@ case class Project(override val id: ObjectId = ObjectId.Uninitialized,
           .map { case (_, tags) =>
             tags.maxBy { tag =>
               versions
-                .filter(_.tagIds.contains(tag.id.get))
+                .filter(_.tagIds.contains(tag.id.value))
                 .filter(!_.isDeleted)
                 // get the latest version
-                .map(_.createdAt.get.toInstant.toEpochMilli)
+                .map(_.createdAt.value.toInstant.toEpochMilli)
                 .max
             }
           }

--- a/app/models/project/ProjectSettings.scala
+++ b/app/models/project/ProjectSettings.scala
@@ -25,6 +25,7 @@ import util.StringUtils._
 import scala.concurrent.{ExecutionContext, Future}
 
 import ore.user.MembershipDossier
+import db.{ObjectId, ObjectReference, ObjectTimestamp}
 
 /**
   * Represents a [[Project]]'s settings.
@@ -38,9 +39,9 @@ import ore.user.MembershipDossier
   * @param _licenseName Project license name
   * @param _licenseUrl  Project license URL
   */
-case class ProjectSettings(override val id: Option[Int] = None,
-                           override val createdAt: Option[Timestamp] = None,
-                           override val projectId: Int = -1,
+case class ProjectSettings(override val id: ObjectId = ObjectId.Uninitialized,
+                           override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                           override val projectId: ObjectReference = -1,
                            homepage: Option[String] = None,
                            private var _issues: Option[String] = None,
                            private var _source: Option[String] = None,
@@ -189,11 +190,11 @@ case class ProjectSettings(override val id: Option[Int] = None,
           type RoleType = ProjectRole
         } = project.memberships
         Future.sequence(formData.build().map { role =>
-          dossier.addRole(role.copy(projectId = project.id.get))
+          dossier.addRole(role.copy(projectId = project.id.value))
         }).flatMap { roles =>
           val notifications = roles.map { role =>
             Notification(
-              createdAt = Some(Timestamp.from(Instant.now())),
+              createdAt = ObjectTimestamp(Timestamp.from(Instant.now())),
               userId = role.userId,
               originId = project.ownerId,
               notificationType = NotificationTypes.ProjectInvite,
@@ -232,6 +233,5 @@ case class ProjectSettings(override val id: Option[Int] = None,
   }
   private lazy val updateMemberShip = Compiled(memberShipUpdate _)
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): ProjectSettings = this.copy(id = id, createdAt = theTime)
-
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): ProjectSettings = this.copy(id = id, createdAt = theTime)
 }

--- a/app/models/project/Tag.scala
+++ b/app/models/project/Tag.scala
@@ -1,39 +1,40 @@
 package models.project
 
 import java.sql.Timestamp
+import java.time.Instant
 
 import db.impl.OrePostgresDriver.api._
 import db.impl.model.OreModel
 import db.impl.table.ModelKeys._
 import db.impl.{OrePostgresDriver, TagTable}
 import db.table.MappedType
-import db.{ModelService, Named}
+import db.{ModelService, Named, ObjectId, ObjectReference, ObjectTimestamp}
 import models.project.TagColors.TagColor
 import slick.jdbc.JdbcType
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class Tag(override val id: Option[Int] = None,
+case class Tag(override val id: ObjectId = ObjectId.Uninitialized,
                private var _versionIds: List[Int],
                name: String,
                data: String,
                color: TagColor)
-  extends OreModel(id, None)
+  extends OreModel(id, ObjectTimestamp.Uninitialized)
     with Named {
+
+  override val createdAt: ObjectTimestamp = ObjectTimestamp(Timestamp.from(Instant.EPOCH))
 
   override type M = Tag
   override type T = TagTable
 
-  def versionIds: List[Int] = this._versionIds
+  def versionIds: List[ObjectReference] = this._versionIds
 
-  def addVersionId(versionId: Int): Unit = {
+  def addVersionId(versionId: ObjectReference): Unit = {
     this._versionIds = this._versionIds :+ versionId
     if (isDefined) {
       update(TagVersionIds)
     }
   }
-
-  def copyWith(id: Option[Int], theTime: Option[Timestamp]): Tag = this.copy(id = id)
 
   /**
     * Used to convert a ghost tag to a normal tag
@@ -51,6 +52,7 @@ case class Tag(override val id: Option[Int] = None,
     } yield tag
   }
 
+  def copyWith(id: ObjectId, theTime: ObjectTimestamp): Tag = this.copy(id = id)
 }
 
 object TagColors extends Enumeration {

--- a/app/models/project/UnsafeDownload.scala
+++ b/app/models/project/UnsafeDownload.scala
@@ -1,8 +1,7 @@
 package models.project
 
-import java.sql.Timestamp
-
 import com.github.tminglei.slickpg.InetString
+import db.{ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.UnsafeDownloadsTable
 import db.impl.model.OreModel
 import ore.project.io.DownloadTypes.DownloadType
@@ -16,15 +15,14 @@ import ore.project.io.DownloadTypes.DownloadType
   * @param address      Address of client
   * @param downloadType Type of download
   */
-case class UnsafeDownload(override val id: Option[Int] = None,
-                          override val createdAt: Option[Timestamp] = None,
-                          userId: Option[Int] = None,
+case class UnsafeDownload(override val id: ObjectId = ObjectId.Uninitialized,
+                          override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                          userId: Option[ObjectReference] = None,
                           address: InetString,
                           downloadType: DownloadType) extends OreModel(id, createdAt) {
 
   override type M = UnsafeDownload
   override type T = UnsafeDownloadsTable
 
-  def copyWith(id: Option[Int], theTime: Option[Timestamp]): UnsafeDownload = this.copy(id = id, createdAt = theTime)
-
+  def copyWith(id: ObjectId, theTime: ObjectTimestamp): UnsafeDownload = this.copy(id = id, createdAt = theTime)
 }

--- a/app/models/project/Version.scala
+++ b/app/models/project/Version.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 
 import com.google.common.base.Preconditions.{checkArgument, checkNotNull}
 
-import db.ModelService
+import db.{ModelService, ObjectId, ObjectReference, ObjectTimestamp}
 import db.access.ModelAccess
 import db.impl.OrePostgresDriver.api._
 import db.impl.model.OreModel
@@ -41,8 +41,8 @@ import models.project.VisibilityTypes.{Public, Visibility}
   * @param projectId        ID of project this version belongs to
   * @param channelId        ID of channel this version belongs to
   */
-case class Version(override val id: Option[Int] = None,
-                   override val createdAt: Option[Timestamp] = None,
+case class Version(override val id: ObjectId = ObjectId.Uninitialized,
+                   override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                    override val projectId: Int,
                    versionString: String,
                    dependencyIds: List[String] = List(),
@@ -50,13 +50,13 @@ case class Version(override val id: Option[Int] = None,
                    channelId: Int = -1,
                    fileSize: Long,
                    hash: String,
-                   private var _authorId: Int = -1,
+                   private var _authorId: ObjectReference = -1,
                    private var _description: Option[String] = None,
                    private var _downloads: Int = 0,
                    private var _isReviewed: Boolean = false,
-                   private var _reviewerId: Int = -1,
+                   private var _reviewerId: ObjectReference = -1,
                    private var _approvedAt: Option[Timestamp] = None,
-                   private var _tagIds: List[Int] = List(),
+                   private var _tagIds: List[ObjectReference] = List(),
                    private var _visibility: Visibility = Public,
                    fileName: String,
                    signatureFileName: String,
@@ -96,7 +96,7 @@ case class Version(override val id: Option[Int] = None,
     */
   def findChannelFrom(channels: Seq[Channel]): Option[Channel] = Defined {
     if (channels == null) None
-    else channels.find(_.id.get == this.channelId)
+    else channels.find(_.id.value == this.channelId)
   }
 
   /**
@@ -149,11 +149,11 @@ case class Version(override val id: Option[Int] = None,
     if (isDefined) update(IsReviewed)
   }
 
-  def authorId: Int = this._authorId
+  def authorId: ObjectReference = this._authorId
 
   def author(implicit ec: ExecutionContext): OptionT[Future, User] = this.userBase.get(this._authorId)
 
-  def setAuthorId(authorId: Int) = {
+  def setAuthorId(authorId: ObjectReference) = {
     this._authorId = authorId
     // If the project is in the Database
     if (isDefined) {
@@ -161,16 +161,13 @@ case class Version(override val id: Option[Int] = None,
     }
   }
 
-  def reviewerId: Int = this._reviewerId
+  def reviewerId: ObjectReference = this._reviewerId
 
   def reviewer(implicit ec: ExecutionContext): OptionT[Future, User] = this.userBase.get(this._reviewerId)
 
-  def setReviewer(reviewer: User): Future[Int] = Defined {
-    this._reviewerId = reviewer.id.get
-    update(ReviewerId)
-  }
+  def setReviewer(reviewer: User): Future[Int] = setReviewerId(reviewer.id.value)
 
-  def setReviewerId(reviewer: Int): Future[Int] = Defined {
+  def setReviewerId(reviewer: ObjectReference): Future[Int] = Defined {
     this._reviewerId = reviewer
     update(ReviewerId)
   }
@@ -189,15 +186,15 @@ case class Version(override val id: Option[Int] = None,
     update(IsNonReviewedVersion)
   }
 
-  def tagIds: List[Int] = this._tagIds
+  def tagIds: List[ObjectReference] = this._tagIds
 
-  def setTagIds(tags: List[Int]) = {
+  def setTagIds(tags: List[ObjectReference]) = {
     this._tagIds = tags
     if(isDefined) update(TagIds)
   }
 
   def addTag(tag: Tag): Unit = {
-    this._tagIds = this._tagIds :+ tag.id.get
+    this._tagIds = this._tagIds :+ tag.id.value
     if (isDefined) {
       update(TagIds)
     }
@@ -298,16 +295,16 @@ case class Version(override val id: Option[Int] = None,
     }
   }
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Version = this.copy(id = id, createdAt = theTime)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Version = this.copy(id = id, createdAt = theTime)
   override def hashCode(): Int = this.id.hashCode
-  override def equals(o: Any): Boolean = o.isInstanceOf[Version] && o.asInstanceOf[Version].id.get == this.id.get
+  override def equals(o: Any): Boolean = o.isInstanceOf[Version] && o.asInstanceOf[Version].id.value == this.id.value
 
-  def byCreationDate(first: Review, second: Review): Boolean = first.createdAt.getOrElse(Timestamp.from(Instant.MIN)).getTime < second.createdAt.getOrElse(Timestamp.from(Instant.MIN)).getTime
+  def byCreationDate(first: Review, second: Review): Boolean = first.createdAt.value.getTime < second.createdAt.value.getTime
   def reviewEntries: ModelAccess[Review] = this.schema.getChildren[Review](classOf[Review], this)
-  def unfinishedReviews(implicit ec: ExecutionContext): Future[Seq[Review]] = reviewEntries.all.map(_.toSeq.filter(rev => rev.createdAt.isDefined && rev.endedAt.isEmpty).sortWith(byCreationDate))
+  def unfinishedReviews(implicit ec: ExecutionContext): Future[Seq[Review]] = reviewEntries.all.map(_.toSeq.filter(rev => rev.createdAt.unsafeToOption.isDefined && rev.endedAt.isEmpty).sortWith(byCreationDate))
   def mostRecentUnfinishedReview(implicit ec: ExecutionContext): OptionT[Future, Review] = OptionT(unfinishedReviews.map(_.headOption))
   def mostRecentReviews(implicit ec: ExecutionContext): Future[Seq[Review]] = reviewEntries.toSeq.map(_.sortWith(byCreationDate))
-  def reviewById(id: Int)(implicit ec: ExecutionContext): OptionT[Future, Review] = reviewEntries.find(equalsInt[ReviewTable](_.id, id))
+  def reviewById(id: ObjectReference)(implicit ec: ExecutionContext): OptionT[Future, Review] = reviewEntries.find(equalsInt[ReviewTable](_.id, id))
   def equalsInt[T <: Table[_]](int1: T => Rep[Int], int2: Int): T => Rep[Boolean] = int1(_) === int2
 
 }

--- a/app/models/project/Version.scala
+++ b/app/models/project/Version.scala
@@ -256,7 +256,7 @@ case class Version(override val id: ObjectId = ObjectId.Uninitialized,
         0
     }
     cnt.value.flatMap { _ =>
-      val change = VersionVisibilityChange(None, Some(Timestamp.from(Instant.now())), Some(creator), this.id.get, comment, None, None, visibility.id)
+      val change = VersionVisibilityChange(ObjectId.Uninitialized, ObjectTimestamp(Timestamp.from(Instant.now())), Some(creator), this.id.value, comment, None, None, visibility.id)
       this.service.access[VersionVisibilityChange](classOf[VersionVisibilityChange]).add(change)
     }
   }
@@ -301,7 +301,7 @@ case class Version(override val id: ObjectId = ObjectId.Uninitialized,
 
   def byCreationDate(first: Review, second: Review): Boolean = first.createdAt.value.getTime < second.createdAt.value.getTime
   def reviewEntries: ModelAccess[Review] = this.schema.getChildren[Review](classOf[Review], this)
-  def unfinishedReviews(implicit ec: ExecutionContext): Future[Seq[Review]] = reviewEntries.all.map(_.toSeq.filter(rev => rev.createdAt.unsafeToOption.isDefined && rev.endedAt.isEmpty).sortWith(byCreationDate))
+  def unfinishedReviews(implicit ec: ExecutionContext): Future[Seq[Review]] = reviewEntries.all.map(_.toSeq.filter(_.endedAt.isEmpty).sortWith(byCreationDate))
   def mostRecentUnfinishedReview(implicit ec: ExecutionContext): OptionT[Future, Review] = OptionT(unfinishedReviews.map(_.headOption))
   def mostRecentReviews(implicit ec: ExecutionContext): Future[Seq[Review]] = reviewEntries.toSeq.map(_.sortWith(byCreationDate))
   def reviewById(id: ObjectReference)(implicit ec: ExecutionContext): OptionT[Future, Review] = reviewEntries.find(equalsInt[ReviewTable](_.id, id))

--- a/app/models/statistic/ProjectView.scala
+++ b/app/models/statistic/ProjectView.scala
@@ -1,7 +1,5 @@
 package models.statistic
 
-import java.sql.Timestamp
-
 import com.github.tminglei.slickpg.InetString
 import com.google.common.base.Preconditions._
 import controllers.sugar.Requests.ProjectRequest
@@ -15,6 +13,7 @@ import util.instances.future._
 import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.sugar.Requests
+import db.{ObjectId, ObjectReference, ObjectTimestamp}
 
 /**
   * Represents a unique view on a Project.
@@ -26,8 +25,8 @@ import controllers.sugar.Requests
   * @param cookie     Browser cookie
   * @param userId     User ID
   */
-case class ProjectView(override val id: Option[Int] = None,
-                       override val createdAt: Option[Timestamp] = None,
+case class ProjectView(override val id: ObjectId = ObjectId.Uninitialized,
+                       override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                        override val modelId: Int,
                        override val address: InetString,
                        override val cookie: String,
@@ -38,9 +37,8 @@ case class ProjectView(override val id: Option[Int] = None,
   override type M = ProjectView
   override type T = ProjectViewsTable
 
-  override def projectId: Int = this.modelId
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): ProjectView = this.copy(id = id, createdAt = theTime)
-
+  override def projectId: ObjectReference = this.modelId
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): ProjectView = this.copy(id = id, createdAt = theTime)
 }
 
 object ProjectView {
@@ -56,9 +54,9 @@ object ProjectView {
     implicit val r: Requests.OreRequest[_] = request.request
     checkNotNull(request, "null request", "")
     checkNotNull(users, "null user base", "")
-    users.current.subflatMap(_.id).value.map { userId =>
+    users.current.map(_.id.value).value.map { userId =>
       val view = ProjectView(
-        modelId = request.data.project.id.get,
+        modelId = request.data.project.id.value,
         address = InetString(remoteAddress),
         cookie = currentCookie,
         _userId = userId

--- a/app/models/statistic/StatEntry.scala
+++ b/app/models/statistic/StatEntry.scala
@@ -4,7 +4,7 @@ import java.sql.Timestamp
 
 import com.github.tminglei.slickpg.InetString
 import com.google.common.base.Preconditions._
-import db.Model
+import db.{Model, ObjectId, ObjectTimestamp}
 import db.impl.model.OreModel
 import db.impl.table.ModelKeys._
 import db.impl.table.StatTable
@@ -24,8 +24,8 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param cookie     Browser cookie
   * @param _userId     User ID
   */
-abstract class StatEntry[Subject <: Model](override val id: Option[Int] = None,
-                                           override val createdAt: Option[Timestamp] = None,
+abstract class StatEntry[Subject <: Model](override val id: ObjectId = ObjectId.Uninitialized,
+                                           override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                                            val modelId: Int,
                                            val address: InetString,
                                            val cookie: String,
@@ -57,7 +57,7 @@ abstract class StatEntry[Subject <: Model](override val id: Option[Int] = None,
   def setUser(user: User) = {
     checkNotNull(user, "user is null", "")
     checkArgument(user.isDefined, "undefined user", "")
-    this._userId = user.id
+    this._userId = Some(user.id.value)
     if (isDefined) update(UserId)
   }
 

--- a/app/models/statistic/VersionDownload.scala
+++ b/app/models/statistic/VersionDownload.scala
@@ -1,7 +1,5 @@
 package models.statistic
 
-import java.sql.Timestamp
-
 import com.github.tminglei.slickpg.InetString
 import com.google.common.base.Preconditions._
 import controllers.sugar.Requests.ProjectRequest
@@ -13,6 +11,8 @@ import util.instances.future._
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import db.{ObjectId, ObjectTimestamp}
+
 /**
   * Represents a unique download on a Project Version.
   *
@@ -23,8 +23,8 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param cookie     Browser cookie
   * @param _userId     User ID
   */
-case class VersionDownload(override val id: Option[Int] = None,
-                           override val createdAt: Option[Timestamp] = None,
+case class VersionDownload(override val id: ObjectId = ObjectId.Uninitialized,
+                           override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                            override val modelId: Int,
                            override val address: InetString,
                            override val cookie: String,
@@ -34,7 +34,7 @@ case class VersionDownload(override val id: Option[Int] = None,
   override type M = VersionDownload
   override type T = VersionDownloadsTable
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): VersionDownload = this.copy(id = id, createdAt = theTime)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): VersionDownload = this.copy(id = id, createdAt = theTime)
 
 }
 
@@ -53,9 +53,9 @@ object VersionDownload {
     checkArgument(version.isDefined, "undefined version", "")
     checkNotNull(request, "null request", "")
     checkNotNull(users, "null user base", "")
-    users.current.subflatMap(_.id).value.map { userId =>
+    users.current.map(_.id.value).value.map { userId =>
       val dl = VersionDownload(
-        modelId = version.id.get,
+        modelId = version.id.value,
         address = InetString(remoteAddress),
         cookie = currentCookie,
         _userId = userId

--- a/app/models/user/LoggedAction.scala
+++ b/app/models/user/LoggedAction.scala
@@ -1,22 +1,20 @@
 package models.user
 
-import java.sql.Timestamp
-
 import scala.collection.immutable
 
 import com.github.tminglei.slickpg.InetString
+
 import controllers.sugar.Requests.AuthRequest
-import db.ModelService
+import db.{ModelService, ObjectId, ObjectTimestamp}
 import db.impl.LoggedActionTable
 import db.impl.model.OreModel
 import enumeratum.values.{IntEnum, IntEnumEntry}
 import ore.StatTracker
 import ore.user.UserOwned
-
 import scala.concurrent.ExecutionContext
 
-case class LoggedActionModel(override val id: Option[Int] = None,
-                             override val createdAt: Option[Timestamp] = None,
+case class LoggedActionModel(override val id: ObjectId = ObjectId.Uninitialized,
+                             override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                              private val _userId: Int,
                              private val _address: InetString,
                              private val _action: LoggedAction,
@@ -28,7 +26,7 @@ case class LoggedActionModel(override val id: Option[Int] = None,
   override type T = LoggedActionTable
   override type M = LoggedActionModel
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): LoggedActionModel = this.copy(createdAt = theTime)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): LoggedActionModel = this.copy(createdAt = theTime)
   override def userId: Int = _userId
 
   def address: InetString = _address
@@ -86,7 +84,7 @@ object UserActionLogger {
   def log(request: AuthRequest[_], action: LoggedAction, actionContextId: Int, newState: String, oldState: String)
          (implicit service: ModelService, ex: ExecutionContext){
 
-    service.insert(LoggedActionModel(None, None, request.user.userId, InetString(StatTracker.remoteAddress(request.request)), action, action.context, actionContextId, newState, oldState))
+    service.insert(LoggedActionModel(ObjectId.Uninitialized, ObjectTimestamp.Uninitialized, request.user.userId, InetString(StatTracker.remoteAddress(request.request)), action, action.context, actionContextId, newState, oldState))
   }
 
 }

--- a/app/models/user/Notification.scala
+++ b/app/models/user/Notification.scala
@@ -2,7 +2,7 @@ package models.user
 
 import java.sql.Timestamp
 
-import db.Model
+import db.{Model, ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.NotificationTable
 import db.impl.model.OreModel
 import db.impl.table.ModelKeys._
@@ -24,10 +24,10 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param action           Action to perform on click
   * @param read             True if notification has been read
   */
-case class Notification(override val id: Option[Int] = None,
-                        override val createdAt: Option[Timestamp] = None,
-                        override val userId: Int = -1,
-                        originId: Int,
+case class Notification(override val id: ObjectId = ObjectId.Uninitialized,
+                        override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                        override val userId: ObjectReference = -1,
+                        originId: ObjectReference,
                         notificationType: NotificationType,
                         messageArgs: List[String],
                         action: Option[String] = None,
@@ -65,6 +65,6 @@ case class Notification(override val id: Option[Int] = None,
     update(Read)
   }
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Model = this.copy(id = id, createdAt = theTime)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Model = this.copy(id = id, createdAt = theTime)
 
 }

--- a/app/models/user/Session.scala
+++ b/app/models/user/Session.scala
@@ -5,11 +5,11 @@ import java.sql.Timestamp
 import db.impl.SessionTable
 import db.impl.access.UserBase
 import db.impl.model.OreModel
-import db.{Expirable, Model}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import util.functional.OptionT
+import db.{Expirable, Model, ObjectId, ObjectTimestamp}
 
 /**
   * Represents a persistant [[User]] session.
@@ -20,8 +20,8 @@ import util.functional.OptionT
   * @param username   Username session belongs to
   * @param token      Unique token
   */
-case class Session(override val id: Option[Int] = None,
-                   override val createdAt: Option[Timestamp] = None,
+case class Session(override val id: ObjectId = ObjectId.Uninitialized,
+                   override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                    override val expiration: Timestamp,
                    username: String,
                    token: String) extends OreModel(id, createdAt) with Expirable {
@@ -37,6 +37,6 @@ case class Session(override val id: Option[Int] = None,
     */
   def user(implicit users: UserBase, ec: ExecutionContext): OptionT[Future, User] = users.withName(this.username)
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Model = this.copy(id = id, createdAt = theTime)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Model = this.copy(id = id, createdAt = theTime)
 
 }

--- a/app/models/user/SignOn.scala
+++ b/app/models/user/SignOn.scala
@@ -4,6 +4,7 @@ import java.sql.Timestamp
 
 import scala.concurrent.Future
 
+import db.{ObjectId, ObjectTimestamp}
 import db.impl.SignOnTable
 import db.impl.model.OreModel
 import db.impl.table.ModelKeys._
@@ -16,8 +17,8 @@ import db.impl.table.ModelKeys._
   * @param nonce        Nonce used
   * @param _isCompleted True if sign on was completed
   */
-case class SignOn(override val id: Option[Int] = None,
-                  override val createdAt: Option[Timestamp] = None,
+case class SignOn(override val id: ObjectId = ObjectId.Uninitialized,
+                  override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                   nonce: String,
                   var _isCompleted: Boolean = false) extends OreModel(id, createdAt) {
 
@@ -31,6 +32,5 @@ case class SignOn(override val id: Option[Int] = None,
     update(IsCompleted)
   }
 
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): SignOn = this.copy(id = id, createdAt = theTime)
-
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): SignOn = this.copy(id = id, createdAt = theTime)
 }

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -402,7 +402,7 @@ case class User(override val id: ObjectId = ObjectId.Uninitialized,
           if (groups.trim == "")
             Set.empty
           else
-            groups.split(",").flatMap(group => RoleTypes.withInternalName(group)).toSet[RoleType]
+            groups.split(",").flatMap(RoleType.withValueOpt).toSet[RoleType]
         )
       }
     }

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -3,7 +3,8 @@ package models.user
 import java.sql.Timestamp
 
 import com.google.common.base.Preconditions._
-import db.{ModelFilter, Named}
+
+import db.{ModelFilter, Named, ObjectId, ObjectReference, ObjectTimestamp}
 import db.access.{ModelAccess, ModelAssociationAccess}
 import db.impl.OrePostgresDriver.api._
 import db.impl._
@@ -26,7 +27,6 @@ import slick.lifted.{QueryBase, TableQuery}
 import util.StringUtils._
 import util.instances.future._
 import util.functional.OptionT
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.Breaks._
 
@@ -42,8 +42,8 @@ import play.api.i18n.Lang
   * @param _email    Email
   * @param _tagline  The user configured "tagline" displayed on the user page.
   */
-case class User(override val id: Option[Int] = None,
-                override val createdAt: Option[Timestamp] = None,
+case class User(override val id: ObjectId = ObjectId.Uninitialized,
+                override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                 private var _name: Option[String] = None,
                 private var _username: String = null,
                 private var _email: Option[String] = None,
@@ -313,7 +313,7 @@ case class User(override val id: Option[Int] = None,
       case GlobalScope =>
         Future.successful(this.globalRoles.map(_.trust).toList.sorted.lastOption.getOrElse(Default))
       case pScope: ProjectScope =>
-        this.service.DB.db.run(Project.roleForTrustQuery(pScope.projectId, this.id.get).result).map { projectRoles =>
+        this.service.DB.db.run(Project.roleForTrustQuery(pScope.projectId, this.id.value).result).map { projectRoles =>
           projectRoles.sortBy(_.roleType.trust).headOption.map(_.roleType.trust).getOrElse(Default)
         } flatMap { userTrust =>
           if (!userTrust.equals(Default)) {
@@ -458,7 +458,7 @@ case class User(override val id: Option[Int] = None,
     * @return True if organization
     */
   def isOrganization(implicit ec: ExecutionContext): Future[Boolean] = Defined {
-    this.service.getModelBase(classOf[OrganizationBase]).exists(_.id === this.id.get)
+    this.service.getModelBase(classOf[OrganizationBase]).exists(_.id === this.id.value)
   }
 
   /**
@@ -467,12 +467,12 @@ case class User(override val id: Option[Int] = None,
     * @return Organization
     */
   def toOrganization(implicit ec: ExecutionContext): Future[Organization] = Defined {
-    this.service.getModelBase(classOf[OrganizationBase]).get(this.id.get)
+    this.service.getModelBase(classOf[OrganizationBase]).get(this.id.value)
       .getOrElse(throw new IllegalStateException("user is not an organization"))
   }
 
   def toMaybeOrganization(implicit ec: ExecutionContext): OptionT[Future, Organization] = Defined {
-    this.service.getModelBase(classOf[OrganizationBase]).get(this.id.get)
+    this.service.getModelBase(classOf[OrganizationBase]).get(this.id.value)
   }
 
   /**
@@ -515,7 +515,7 @@ case class User(override val id: Option[Int] = None,
   def hasUnresolvedFlagFor(project: Project)(implicit ec: ExecutionContext): Future[Boolean] = {
     checkNotNull(project, "null project", "")
     checkArgument(project.isDefined, "undefined project", "")
-    this.flags.exists(f => f.projectId === project.id.get && !f.isResolved)
+    this.flags.exists(f => f.projectId === project.id.value && !f.isResolved)
   }
 
   /**
@@ -534,7 +534,7 @@ case class User(override val id: Option[Int] = None,
   def sendNotification(notification: Notification)(implicit ec: ExecutionContext): Future[Notification] = {
     checkNotNull(notification, "null notification", "")
     this.config.debug("Sending notification: " + notification, -1)
-    this.service.access[Notification](classOf[Notification]).add(notification.copy(userId = this.id.get))
+    this.service.access[Notification](classOf[Notification]).add(notification.copy(userId = this.id.value))
   }
 
   /**
@@ -583,11 +583,8 @@ case class User(override val id: Option[Int] = None,
   def url: String = this.username
 
   override val scope: GlobalScope.type = GlobalScope
-
-  override def userId: Int = this.id.get
-
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): User = this.copy(createdAt = theTime)
-
+  override def userId: ObjectReference = this.id.value
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): User = this.copy(createdAt = theTime)
 }
 
 object User {
@@ -601,7 +598,7 @@ object User {
   def fromSponge(toConvert: SpongeUser)(implicit config: OreConfig, ec: ExecutionContext): User = {
     val user = User()
     user.fill(toConvert)
-    user.copy(id = Some(toConvert.id))
+    user.copy(id = ObjectId(toConvert.id))
   }
 
 }

--- a/app/models/user/role/OrganizationRole.scala
+++ b/app/models/user/role/OrganizationRole.scala
@@ -1,8 +1,6 @@
 package models.user.role
 
-import java.sql.Timestamp
-
-import db.Model
+import db.{Model, ObjectId, ObjectReference, ObjectTimestamp}
 import db.impl.OrganizationRoleTable
 import ore.Visitable
 import ore.permission.role.RoleType
@@ -20,10 +18,10 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param _roleType      Type of Role
   * @param _isAccepted    True if has been accepted
   */
-case class OrganizationRole(override val id: Option[Int] = None,
-                            override val createdAt: Option[Timestamp] = None,
-                            override val userId: Int,
-                            override val organizationId: Int = -1,
+case class OrganizationRole(override val id: ObjectId = ObjectId.Uninitialized,
+                            override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
+                            override val userId: ObjectReference,
+                            override val organizationId: ObjectReference = -1,
                             private val _roleType: RoleType,
                             private val _isAccepted: Boolean = false)
                             extends RoleModel(id, createdAt, userId, _roleType, _isAccepted)
@@ -32,9 +30,9 @@ case class OrganizationRole(override val id: Option[Int] = None,
   override type M = OrganizationRole
   override type T = OrganizationRoleTable
 
-  def this(userId: Int, roleType: RoleType) = this(userId = userId, _roleType = roleType)
+  def this(userId: ObjectReference, roleType: RoleType) = this(userId = userId, _roleType = roleType)
 
   override def subject(implicit ec: ExecutionContext): Future[Visitable] = this.organization
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): Model = this.copy(id = id, createdAt = theTime)
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): Model = this.copy(id = id, createdAt = theTime)
 
 }

--- a/app/models/user/role/ProjectRole.scala
+++ b/app/models/user/role/ProjectRole.scala
@@ -1,13 +1,13 @@
 package models.user.role
 
-import java.sql.Timestamp
-
 import db.impl.ProjectRoleTable
 import ore.Visitable
 import ore.permission.role.RoleType
 import ore.permission.scope.ProjectScope
 
 import scala.concurrent.{ExecutionContext, Future}
+
+import db.{ObjectId, ObjectTimestamp}
 
 /**
   * Represents a [[ore.project.ProjectMember]]'s role in a
@@ -20,8 +20,8 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param _roleType  Type of role
   * @param projectId  ID of project this role belongs to
   */
-case class ProjectRole(override val id: Option[Int] = None,
-                       override val createdAt: Option[Timestamp] = None,
+case class ProjectRole(override val id: ObjectId = ObjectId.Uninitialized,
+                       override val createdAt: ObjectTimestamp = ObjectTimestamp.Uninitialized,
                        override val userId: Int,
                        override val projectId: Int,
                        private val _roleType: RoleType,
@@ -33,8 +33,8 @@ case class ProjectRole(override val id: Option[Int] = None,
   override type T = ProjectRoleTable
 
   def this(userId: Int, roleType: RoleType, projectId: Int, accepted: Boolean, visible: Boolean) = this(
-    id = None,
-    createdAt = None,
+    id = ObjectId.Uninitialized,
+    createdAt = ObjectTimestamp.Uninitialized,
     userId = userId,
     _roleType = roleType,
     projectId = projectId,
@@ -42,6 +42,5 @@ case class ProjectRole(override val id: Option[Int] = None,
   )
 
   override def subject(implicit ec: ExecutionContext): Future[Visitable] = this.project
-  override def copyWith(id: Option[Int], theTime: Option[Timestamp]): ProjectRole = this.copy(id = id, createdAt = theTime)
-
+  override def copyWith(id: ObjectId, theTime: ObjectTimestamp): ProjectRole = this.copy(id = id, createdAt = theTime)
 }

--- a/app/models/user/role/RoleModel.scala
+++ b/app/models/user/role/RoleModel.scala
@@ -14,6 +14,8 @@ import ore.permission.role.RoleType
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import db.{ObjectId, ObjectTimestamp}
+
 /**
   * Represents a [[Role]] in something like a [[models.project.Project]] or
   * [[models.user.Organization]].
@@ -24,8 +26,8 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param _roleType    Type of Role
   * @param _isAccepted  True if has been accepted
   */
-abstract class RoleModel(override val id: Option[Int],
-                         override val createdAt: Option[Timestamp],
+abstract class RoleModel(override val id: ObjectId,
+                         override val createdAt: ObjectTimestamp,
                          override val userId: Int,
                          private var _roleType: RoleType,
                          private var _isAccepted: Boolean = false)

--- a/app/models/viewhelper/HeaderData.scala
+++ b/app/models/viewhelper/HeaderData.scala
@@ -36,7 +36,7 @@ case class HeaderData(currentUser: Option[User] = None,
 
   def hasUser: Boolean = currentUser.isDefined
 
-  def isCurrentUser(userId: Int): Boolean = currentUser.flatMap(_.id).contains(userId)
+  def isCurrentUser(userId: Int): Boolean = currentUser.map(_.id.value).contains(userId)
 
   def globalPerm(perm: Permission): Boolean = globalPermissions.getOrElse(perm, false)
 
@@ -63,7 +63,7 @@ object HeaderData {
 
   val unAuthenticated: HeaderData = HeaderData(None, noPerms)
 
-  def cacheKey(user: User) = s"""user${user.id.get}"""
+  def cacheKey(user: User) = s"""user${user.id.value}"""
 
   def of[A](request: Request[A])(implicit cache: AsyncCacheApi, db: JdbcBackend#DatabaseDef, ec: ExecutionContext, service: ModelService): Future[HeaderData] = {
     OptionT.fromOption[Future](request.cookies.get("_oretoken"))
@@ -96,7 +96,7 @@ object HeaderData {
 
     val tableProject = TableQuery[ProjectTableMain]
     val query = for {
-      p <- tableProject if p.userId === user.id.get && p.visibility === VisibilityTypes.NeedsApproval
+      p <- tableProject if p.userId === user.id.value && p.visibility === VisibilityTypes.NeedsApproval
     } yield {
       p
     }

--- a/app/models/viewhelper/JoinableData.scala
+++ b/app/models/viewhelper/JoinableData.scala
@@ -18,7 +18,7 @@ trait JoinableData[R <: RoleModel, M <: Member[R], T <: Joinable[M]] {
 
   def filteredMembers(implicit request: OreRequest[_]): Seq[(R, User)] = {
     if (request.data.globalPerm(EditSettings) || // has EditSettings show all
-      request.currentUser.map(_.id.get).contains(joinable.ownerId) // Current User is owner
+      request.currentUser.map(_.id.value).contains(joinable.ownerId) // Current User is owner
     ) members
     else {
       members.filter {

--- a/app/models/viewhelper/OrganizationData.scala
+++ b/app/models/viewhelper/OrganizationData.scala
@@ -41,7 +41,7 @@ object OrganizationData {
       members <- orga.memberships.members
       memberRoles <- Future.sequence(members.map(_.headRole))
       memberUser <- Future.sequence(memberRoles.map(_.user))
-      projectRoles <- db.run(queryProjectRoles(orga.id.get).result)
+      projectRoles <- db.run(queryProjectRoles(orga.id.value).result)
     } yield {
       val members = memberRoles zip memberUser
       OrganizationData(orga, role, members.toSeq, projectRoles)

--- a/app/models/viewhelper/OrganizationData.scala
+++ b/app/models/viewhelper/OrganizationData.scala
@@ -31,7 +31,7 @@ case class OrganizationData(joinable: Organization,
 object OrganizationData {
   val noPerms: Map[Permission, Boolean] = Map(EditSettings -> false)
 
-  def cacheKey(orga: Organization): String = "organization" + orga.id.get
+  def cacheKey(orga: Organization): String = "organization" + orga.id.value
 
   def of[A](orga: Organization)(implicit cache: AsyncCacheApi, db: JdbcBackend#DatabaseDef, ec: ExecutionContext,
                                 service: ModelService): Future[OrganizationData] = {

--- a/app/models/viewhelper/ProjectData.scala
+++ b/app/models/viewhelper/ProjectData.scala
@@ -50,7 +50,7 @@ case class ProjectData(joinable: Project,
 
 object ProjectData {
 
-  def cacheKey(project: Project): String = "project" + project.id.get
+  def cacheKey(project: Project): String = "project" + project.id.value
 
   def of[A](request: OreRequest[A], project: PendingProject)(implicit cache: AsyncCacheApi, db: JdbcBackend#DatabaseDef, ec: ExecutionContext): ProjectData = {
 
@@ -138,7 +138,7 @@ object ProjectData {
     val tableRole = TableQuery[ProjectRoleTable]
 
     val query = for {
-      r <- tableRole if r.projectId === project.id.get
+      r <- tableRole if r.projectId === project.id.value
       u <- tableUser if r.userId === u.id
     } yield {
       (r, u)

--- a/app/models/viewhelper/ScopedOrganizationData.scala
+++ b/app/models/viewhelper/ScopedOrganizationData.scala
@@ -18,7 +18,7 @@ object ScopedOrganizationData {
 
   val noScope = ScopedOrganizationData()
 
-  def cacheKey(orga: Organization, user: User) = s"""organization${orga.id.get}foruser${user.id.get}"""
+  def cacheKey(orga: Organization, user: User) = s"""organization${orga.id.value}foruser${user.id.value}"""
 
   def of[A](currentUser: Option[User], orga: Organization)(implicit cache: AsyncCacheApi, db: JdbcBackend#DatabaseDef, ec: ExecutionContext,
                                                            service: ModelService): Future[ScopedOrganizationData] = {

--- a/app/models/viewhelper/ScopedProjectData.scala
+++ b/app/models/viewhelper/ScopedProjectData.scala
@@ -14,7 +14,7 @@ import util.syntax._
   */
 object ScopedProjectData {
 
-  def cacheKey(project: Project, user: User) = s"""project${project.id.get}foruser${user.id.get}"""
+  def cacheKey(project: Project, user: User) = s"""project${project.id.value}foruser${user.id.value}"""
 
   def of(currentUser: Option[User], project: Project)(implicit ec: ExecutionContext, cache: AsyncCacheApi): Future[ScopedProjectData] = {
     currentUser.map { user =>

--- a/app/models/viewhelper/UserData.scala
+++ b/app/models/viewhelper/UserData.scala
@@ -56,7 +56,7 @@ object UserData {
     val userTable = TableQuery[UserTable]
 
     for {
-      r <- roleTable if r.userId === user.id.get
+      r <- roleTable if r.userId === user.id.value
       o <- orgaTable if r.organizationId === o.id
       u <- userTable if o.id === u.id
       uo <- userTable if o.userId === uo.id

--- a/app/models/viewhelper/VersionData.scala
+++ b/app/models/viewhelper/VersionData.scala
@@ -17,7 +17,7 @@ case class VersionData(p: ProjectData, v: Version, c: Channel,
                        approvedBy: Option[String], // Reviewer if present
                        dependencies: Seq[(Dependency, Option[Project])]) {
 
-  def isRecommended: Boolean = p.project.recommendedVersionId == v.id
+  def isRecommended: Boolean = p.project.recommendedVersionId.contains(v.id.value)
 
   def fullSlug = s"""${p.fullSlug}/versions/${v.versionString}"""
 

--- a/app/ore/Platforms.scala
+++ b/app/ore/Platforms.scala
@@ -3,8 +3,9 @@ package ore
 import models.project.{Tag, TagColors}
 import models.project.TagColors.TagColor
 import ore.project.Dependency
-
 import scala.language.implicitConversions
+
+import db.ObjectId
 
 /**
   * The Platform a plugin/mod runs on
@@ -40,7 +41,7 @@ object Platforms extends Enumeration {
                       url: String
                      ) extends super.Val(id, name) {
 
-    def toGhostTag(version: String): Tag = Tag(None, List(), name, version, tagColor)
+    def toGhostTag(version: String): Tag = Tag(ObjectId.Uninitialized, List(), name, version, tagColor)
 
   }
 

--- a/app/ore/project/ProjectOwned.scala
+++ b/app/ore/project/ProjectOwned.scala
@@ -6,12 +6,14 @@ import util.instances.future._
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import db.ObjectReference
+
 /**
   * Represents anything that has a [[models.project.Project]].
   */
 trait ProjectOwned {
   /** Returns the Project ID */
-  def projectId: Int
+  def projectId: ObjectReference
   /** Returns the Project */
   def project(implicit projects: ProjectBase, ec: ExecutionContext): Future[Project] =
     projects.get(this.projectId).getOrElse(throw new NoSuchElementException("Get on None"))

--- a/app/ore/project/ProjectTask.scala
+++ b/app/ore/project/ProjectTask.scala
@@ -44,8 +44,8 @@ class ProjectTask @Inject()(models: ModelService, actorSystem: ActorSystem, conf
     val dayAgo = System.currentTimeMillis() - draftExpire
 
     projects.foreach(project => {
-      Logger.debug(s"Found project: ${project.ownerName}/${project.slug}")
-      val createdAt = project.createdAt.getOrElse(Timestamp.from(Instant.now())).getTime
+      Logger.info(s"Found project: ${project.ownerName}/${project.slug}")
+      val createdAt = project.createdAt.value.getTime
       if (createdAt < dayAgo) {
         Logger.debug(s"Changed ${project.ownerName}/${project.slug} from New to Public")
         project.setVisibility(VisibilityTypes.Public, "Changed by task", project.ownerId)

--- a/app/ore/project/ProjectTask.scala
+++ b/app/ore/project/ProjectTask.scala
@@ -44,7 +44,7 @@ class ProjectTask @Inject()(models: ModelService, actorSystem: ActorSystem, conf
     val dayAgo = System.currentTimeMillis() - draftExpire
 
     projects.foreach(project => {
-      Logger.info(s"Found project: ${project.ownerName}/${project.slug}")
+      Logger.debug(s"Found project: ${project.ownerName}/${project.slug}")
       val createdAt = project.createdAt.value.getTime
       if (createdAt < dayAgo) {
         Logger.debug(s"Changed ${project.ownerName}/${project.slug} from New to Public")

--- a/app/ore/project/factory/PendingVersion.scala
+++ b/app/ore/project/factory/PendingVersion.scala
@@ -10,6 +10,8 @@ import play.api.cache.SyncCacheApi
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import db.ObjectId
+
 package object TagAlias {
   type ProjectTag = models.project.Tag
 }

--- a/app/ore/project/factory/ProjectFactory.scala
+++ b/app/ore/project/factory/ProjectFactory.scala
@@ -394,7 +394,7 @@ trait ProjectFactory {
   private def addMetadataTags(pluginFileData: Option[PluginFileData], version: Version)(implicit ec: ExecutionContext): Future[Seq[ProjectTag]] = {
     Future.sequence(pluginFileData.map(_.ghostTags.map(_.getFilledTag(service))).toList.flatten).map(
       _.map { tag =>
-        tag.addVersionId(version.id.get)
+        tag.addVersionId(version.id.value)
         version.addTag(tag)
         tag
       })
@@ -407,7 +407,7 @@ trait ProjectFactory {
         version.dependencies.filter(d => dependencyVersionRegex.pattern.matcher(d.version).matches())
       ).map(_.getFilledTag(service))).map(
       _.map { tag =>
-        tag.addVersionId(version.id.get)
+        tag.addVersionId(version.id.value)
         version.addTag(tag)
         tag
       })

--- a/app/ore/project/factory/ProjectFactory.scala
+++ b/app/ore/project/factory/ProjectFactory.scala
@@ -173,7 +173,7 @@ trait ProjectFactory {
     val project = Project.Builder(this.service)
       .pluginId(metaData.id.get)
       .ownerName(owner.name)
-      .ownerId(owner.id.get)
+      .ownerId(owner.id.value)
       .name(metaData.get[String]("name").getOrElse("name not found"))
       .visibility(VisibilityTypes.New)
       .build()
@@ -207,12 +207,12 @@ trait ProjectFactory {
       .versionString(metaData.version.get)
       .dependencyIds(metaData.dependencies.map(d => d.pluginId + ":" + d.version).toList)
       .description(metaData.get[String]("description").getOrElse(""))
-      .projectId(project.id.getOrElse(-1)) // Version might be for an uncreated project
+      .projectId(project.id.unsafeToOption.getOrElse(-1)) // Version might be for an uncreated project
       .fileSize(path.toFile.length)
       .hash(plugin.md5)
       .fileName(path.getFileName.toString)
       .signatureFileName(plugin.signaturePath.getFileName.toString)
-      .authorId(plugin.user.id.get)
+      .authorId(plugin.user.id.value)
       .build()
 
     Right(PendingVersion(
@@ -290,7 +290,7 @@ trait ProjectFactory {
       } = newProject.memberships
       val owner = newProject.owner
       val ownerId = owner.userId
-      val projectId = newProject.id.get
+      val projectId = newProject.id.value
 
       dossier.addRole(new ProjectRole(ownerId, RoleType.ProjectOwner, projectId, accepted = true, visible = true))
       pending.roles.map { role =>
@@ -327,7 +327,7 @@ trait ProjectFactory {
     for {
       channelCount <- project.channels.size
       _ = checkState(channelCount < this.config.projects.get[Int]("max-channels"), "channel limit reached", "")
-      channel <- this.service.access[Channel](classOf[Channel]).add(new Channel(name, color, project.id.get))
+      channel <- this.service.access[Channel](classOf[Channel]).add(new Channel(name, color, project.id.value))
     } yield channel
   }
 
@@ -353,8 +353,8 @@ trait ProjectFactory {
           dependencyIds = pendingVersion.dependencyIds,
           _description = pendingVersion.description,
           assets = pendingVersion.assets,
-          projectId = project.id.get,
-          channelId = channel.id.get,
+          projectId = project.id.value,
+          channelId = channel.id.value,
           fileSize = pendingVersion.fileSize,
           hash = pendingVersion.hash,
           _authorId = pendingVersion.authorId,

--- a/app/ore/project/io/PluginFile.scala
+++ b/app/ore/project/io/PluginFile.scala
@@ -172,6 +172,6 @@ class PluginFile(private var _path: Path, val signaturePath: Path, val user: Use
     pluginEntry
   }
 
-  override def userId: Int = this.user.id.get
+  override def userId: Int = this.user.id.value
 
 }

--- a/app/ore/project/io/PluginFileData.scala
+++ b/app/ore/project/io/PluginFileData.scala
@@ -5,9 +5,10 @@ import java.io.BufferedReader
 import models.project.{Tag, TagColors}
 import ore.project.Dependency
 import org.spongepowered.plugin.meta.McModInfo
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+
+import db.ObjectId
 
 /**
   * The metadata within a [[PluginFile]]
@@ -42,7 +43,7 @@ class PluginFileData(data: Seq[DataValue[_]]) {
   }
 
   def get[T](key: String): Option[T] = {
-    dataValues.filter(_.key == key).filter(_.isInstanceOf[DataValue[T]]).map(_.asInstanceOf[DataValue[T]].value).headOption
+    dataValues.filter(_.key == key).filter(_.isInstanceOf[DataValue[T @unchecked]]).map(_.asInstanceOf[DataValue[T]].value).headOption
   }
 
   def isValidPlugin: Boolean = {
@@ -54,7 +55,7 @@ class PluginFileData(data: Seq[DataValue[_]]) {
     val buffer = new ArrayBuffer[Tag]
 
     if (containsMixins) {
-      val mixinTag = Tag(None, List(), "Mixin", "", TagColors.Mixin)
+      val mixinTag = Tag(ObjectId.Uninitialized, List(), "Mixin", "", TagColors.Mixin)
       buffer += mixinTag
     }
 

--- a/app/ore/rest/OreWrites.scala
+++ b/app/ore/rest/OreWrites.scala
@@ -19,8 +19,8 @@ final class OreWrites @Inject()(implicit config: OreConfig, service: ModelServic
 
   implicit val projectApiKeyWrites: Writes[ProjectApiKey] = new Writes[ProjectApiKey] {
     def writes(key: ProjectApiKey): JsObject = obj(
-      "id" -> key.id.get,
-      "createdAt" -> key.createdAt.get,
+      "id" -> key.id.value,
+      "createdAt" -> key.createdAt.value,
       "keyType" -> obj("id" -> key.keyType.id, "name" -> key.keyType.name),
       "projectId" -> key.projectId,
       "value" -> key.value
@@ -29,8 +29,8 @@ final class OreWrites @Inject()(implicit config: OreConfig, service: ModelServic
 
   implicit val pageWrites: Writes[Page] = new Writes[Page] {
     def writes(page: Page): JsObject = obj(
-      "id" -> page.id.get,
-      "createdAt" -> page.createdAt.get.toString,
+      "id" -> page.id.value,
+      "createdAt" -> page.createdAt.value.toString,
       "parentId" -> page.parentId,
       "name" -> page.name,
       "slug" -> page.slug
@@ -57,7 +57,7 @@ final class OreWrites @Inject()(implicit config: OreConfig, service: ModelServic
   implicit val tagWrites: Writes[Tag] = new Writes[Tag] {
     override def writes(tag: Tag): JsValue = {
       obj(
-        "id" -> tag.id,
+        "id" -> tag.id.value,
         "name" -> tag.name,
         "data" -> tag.data,
         "backgroundColor" -> tag.color.background,

--- a/app/ore/user/FakeUser.scala
+++ b/app/ore/user/FakeUser.scala
@@ -4,6 +4,8 @@ import java.sql.Timestamp
 import java.util.Date
 
 import javax.inject.Inject
+
+import db.ObjectId
 import models.user.User
 import ore.OreConfig
 import ore.permission.role.RoleType
@@ -22,7 +24,7 @@ final class FakeUser @Inject()(config: OreConfig) {
   lazy val isEnabled: Boolean = conf.get[Boolean]("fakeUser.enabled")
 
   lazy private val user = if (isEnabled) User(
-    id = conf.getOptional[Int]("fakeUser.id"),
+    id = ObjectId(conf.get[Int]("fakeUser.id")),
     _name = conf.getOptional[String]("fakeUser.name"),
     _username = conf.get[String]("fakeUser.username"),
     _email = conf.getOptional[String]("fakeUser.email"),

--- a/app/ore/user/MembershipDossier.scala
+++ b/app/ore/user/MembershipDossier.scala
@@ -60,7 +60,7 @@ trait MembershipDossier {
     */
   def members(implicit ec: ExecutionContext): Future[Set[MemberType]] = {
     this.association.all.map(_.map { user =>
-      newMember(user.id.get)
+      newMember(user.id.value)
     })
   }
 
@@ -72,7 +72,7 @@ trait MembershipDossier {
   def addRole(role: RoleType)(implicit ec: ExecutionContext): Future[RoleType] = {
     for {
       user <- role.user
-      exists <- this.roles.exists(_.userId === user.id.get)
+      exists <- this.roles.exists(_.userId === user.id.value)
       _ <- if(!exists) addMember(user) else Future.successful(user)
       ret <- this.roleAccess.add(role)
     } yield ret
@@ -84,7 +84,7 @@ trait MembershipDossier {
     * @param user User to get roles for
     * @return     User roles
     */
-  def getRoles(user: User)(implicit ec: ExecutionContext): Future[Set[RoleType]] = this.roles.filter(_.userId === user.id.get).map(_.toSet)
+  def getRoles(user: User)(implicit ec: ExecutionContext): Future[Set[RoleType]] = this.roles.filter(_.userId === user.id.value).map(_.toSet)
 
   /**
     * Returns the highest level of [[ore.permission.role.Trust]] this user has.
@@ -103,7 +103,7 @@ trait MembershipDossier {
     for {
       _ <- this.roleAccess.remove(role)
       user   <- role.user
-      exists <- this.roles.exists(_.userId === user.id.get)
+      exists <- this.roles.exists(_.userId === user.id.value)
       _ <- if(!exists) removeMember(user) else Future.successful(0)
     } yield ()
   }

--- a/app/views/projects/admin/flags.scala.html
+++ b/app/views/projects/admin/flags.scala.html
@@ -46,7 +46,7 @@
                                 <tr>
                                     <td>@by</td>
                                     <td>@flag.reason, @flag.comment</td>
-                                    <td>@prettifyDateAndTime(flag.createdAt.getOrElse(Timestamp.from(Instant.EPOCH)))</td>
+                                    <td>@prettifyDateAndTime(flag.createdAt.value)</td>
                                     @if(flag.isResolved) {
                                         <td>@resolvedBy.get
                                             at @prettifyDateAndTime(flag.resolvedAt.getOrElse(Timestamp.from(Instant.EPOCH)))</td>

--- a/app/views/projects/channels/list.scala.html
+++ b/app/views/projects/channels/list.scala.html
@@ -58,12 +58,12 @@
                                                         id="channel-delete-@channel.id" data-toggle="modal"
                                                         data-target="#modal-delete">
                                                     } else {
-                                                        id="channel-delete-@channel.id.get" data-channel-delete="safe-delete"
-                                                        data-channel-id="@channel.id.get">
+                                                        id="channel-delete-@channel.id.value" data-channel-delete="safe-delete"
+                                                        data-channel-id="@channel.id.value">
 
                                                         @form(action = channelRoutes.delete(
                                                             p.project.ownerName, p.project.slug, channel.name),
-                                                            'id -> s"form-delete-${channel.id.get}",
+                                                            'id -> s"form-delete-${channel.id.value}",
                                                             'class -> "form-channel-delete") {
                                                             @CSRF.formField
                                                         }

--- a/app/views/projects/create.scala.html
+++ b/app/views/projects/create.scala.html
@@ -53,7 +53,7 @@ Page used for uploading and creating new projects.
                                         <select name="owner" form="continue">
                                             <option value="@project.ownerId" selected>@project.ownerName</option>
                                             @createProjectOrgas.map { organization =>
-                                                <option value="@organization.id.get">@organization.name</option>
+                                                <option value="@organization.id.value">@organization.name</option>
                                             }
                                         </select>
                                     } else {

--- a/app/views/projects/log.scala.html
+++ b/app/views/projects/log.scala.html
@@ -15,6 +15,51 @@
 
 @bootstrap.layout(messages("project.log.logger.title", project.namespace)) {
     <div class="container" style="margin-top: 90px;">
+<<<<<<< master
+=======
+        <div class="row">
+            <div class="col-md-12">
+                <h1>@messages("project.log.visibility.title") <a href="@projectRoutes.show(project.ownerName, project.slug)">@project.ownerName/@project.slug</a></h1>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h4 class="panel-title pull-left">@messages("project.log.visibility.title")</h4>
+                        <div class="clearfix"></div>
+                    </div>
+                    <table class="table table-condensed setting-no-border table-review-log">
+                        <thead>
+                            <tr>
+                                <th>State</th>
+                                <th>Time</th>
+                                <th>Comment</th>
+                                <th>Set by</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @if(visibilityChanges.isEmpty) {
+                                <tr><td>No entries founds</td></tr>
+                            }
+                            @visibilityChanges.reverse.map { case (entry, createdBy) =>
+                                <tr>
+                                    <td>@VisibilityTypes.withId(entry.visibility)</td>
+                                    <td>@prettifyDateAndTime(entry.createdAt.value)</td>
+                                    <td>@entry.renderComment()</td>
+                                    @if(createdBy.isDefined) {
+                                        <td>@createdBy.get.name</td>
+                                    } else {
+                                        <td>Unknown</td>
+                                    }
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+>>>>>>> Replace Option id and timestamp with custom types
 
         <div class="row">
             <div class="col-md-12">
@@ -36,7 +81,7 @@
                             @logs.map { entry =>
                                 <tr>
                                     <td>@entry.message</td>
-                                    <td>@prettifyDateAndTime(entry.createdAt.getOrElse(Timestamp.from(Instant.now())))</td>
+                                    <td>@prettifyDateAndTime(entry.createdAt.value)</td>
                                 </tr>
                             }
                         </tbody>

--- a/app/views/projects/log.scala.html
+++ b/app/views/projects/log.scala.html
@@ -15,51 +15,6 @@
 
 @bootstrap.layout(messages("project.log.logger.title", project.namespace)) {
     <div class="container" style="margin-top: 90px;">
-<<<<<<< master
-=======
-        <div class="row">
-            <div class="col-md-12">
-                <h1>@messages("project.log.visibility.title") <a href="@projectRoutes.show(project.ownerName, project.slug)">@project.ownerName/@project.slug</a></h1>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title pull-left">@messages("project.log.visibility.title")</h4>
-                        <div class="clearfix"></div>
-                    </div>
-                    <table class="table table-condensed setting-no-border table-review-log">
-                        <thead>
-                            <tr>
-                                <th>State</th>
-                                <th>Time</th>
-                                <th>Comment</th>
-                                <th>Set by</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @if(visibilityChanges.isEmpty) {
-                                <tr><td>No entries founds</td></tr>
-                            }
-                            @visibilityChanges.reverse.map { case (entry, createdBy) =>
-                                <tr>
-                                    <td>@VisibilityTypes.withId(entry.visibility)</td>
-                                    <td>@prettifyDateAndTime(entry.createdAt.value)</td>
-                                    <td>@entry.renderComment()</td>
-                                    @if(createdBy.isDefined) {
-                                        <td>@createdBy.get.name</td>
-                                    } else {
-                                        <td>Unknown</td>
-                                    }
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
->>>>>>> Replace Option id and timestamp with custom types
 
         <div class="row">
             <div class="col-md-12">

--- a/app/views/projects/pages/modalPageCreate.scala.html
+++ b/app/views/projects/pages/modalPageCreate.scala.html
@@ -43,7 +43,7 @@
                         <select class="form-control select-parent">
                             <option selected value="-1">&lt;none&gt;</option>
                             @rootPages.filterNot(_.name.equals(Page.HomeName)).map { page =>
-                              <option value="@page.id.get" data-slug="@page.slug">@page.name</option>
+                              <option value="@page.id.value" data-slug="@page.slug">@page.name</option>
                             }
                         </select>
                     </div>

--- a/app/views/projects/pages/view.scala.html
+++ b/app/views/projects/pages/view.scala.html
@@ -61,7 +61,7 @@ Documentation page within Project overview.
 
                     <div class="stats minor">
                         <p>@messages("project.category.info", p.project.category.title)</p>
-                        <p>@messages("project.publishDate", prettifyDate(p.project.createdAt.get))</p>
+                        <p>@messages("project.publishDate", prettifyDate(p.project.createdAt.value))</p>
                         <p>@p.project.viewCount views</p>
                         <p>@NumberFormat.getInstance.format(p.project.downloadCount) total downloads</p>
                         @p.settings.licenseName.map { licenseName =>
@@ -92,12 +92,12 @@ Documentation page within Project overview.
                             @rootPages.filterNot(_._1.name.equals(Page.HomeName)).map { case (pg, children) =>
                                 <li class="list-group-item">
                                     @if(children.nonEmpty) {
-                                        @if(page.parentId != pg.id.get) {
-                                            <a class="page-expand" data-page-id="@pg.id.get">
+                                        @if(page.parentId != pg.id.value) {
+                                            <a class="page-expand" data-page-id="@pg.id.value">
                                                 <i class="fa fa-plus-square-o"></i>
                                             </a>
                                         } else {
-                                            <a class="page-collapse" data-page-id="@pg.id.get">
+                                            <a class="page-collapse" data-page-id="@pg.id.value">
                                                 <i class="fa fa-minus-square-o"></i>
                                             </a>
                                         }
@@ -106,8 +106,8 @@ Documentation page within Project overview.
                                         @pg.name
                                     </a>
                                 </li>
-                              @if(page.parentId != -1 && page.parentId == pg.id.get) {
-                                  <div class="page-children" data-page-id="@pg.id.get">
+                              @if(page.parentId != -1 && page.parentId == pg.id.value) {
+                                  <div class="page-children" data-page-id="@pg.id.value">
                                       @children.map { child =>
                                         <li class="list-group-item page-item-child">
                                             <a href="@routes.Pages.show(p.project.ownerName, p.project.slug, child.fullSlug(Some(pg)))">

--- a/app/views/projects/settings.scala.html
+++ b/app/views/projects/settings.scala.html
@@ -133,7 +133,7 @@
                             </div>
                             <div class="setting-content">
                                 @deploymentKey.map { key =>
-                                  <button class="btn btn-danger btn-block btn-key-revoke" data-key-id="@key.id.get">
+                                  <button class="btn btn-danger btn-block btn-key-revoke" data-key-id="@key.id.value">
                                       <i class="fa fa-spinner fa-spin" style="display: none;"></i>
                                       @messages("project.settings.revokeKey")
                                   </button>

--- a/app/views/projects/versions/create.scala.html
+++ b/app/views/projects/versions/create.scala.html
@@ -145,7 +145,7 @@
                                             <td class="rv">
                                                 <div class="checkbox-inline">
                                                     <input form="form-publish" name="forum-post" type="checkbox"
-                                                            @if(project.project.id.isEmpty || forumSync) { checked } value="true"/>
+                                                            @if(!project.project.isDefined || forumSync) { checked } value="true"/>
                                                 </div>
                                                 <div class="clearfix"></div>
                                             </td>

--- a/app/views/projects/versions/log.scala.html
+++ b/app/views/projects/versions/log.scala.html
@@ -42,7 +42,7 @@
 							@visibilityChanges.reverse.map { case (entry, createdBy) =>
 							<tr>
 								<td>@VisibilityTypes.withId(entry.visibility)</td>
-								<td>@prettifyDateAndTime(entry.createdAt.getOrElse(Timestamp.from(Instant.now())))</td>
+								<td>@prettifyDateAndTime(entry.createdAt.value))))</td>
 								<td>@entry.renderComment()</td>
 								@if(createdBy.isDefined) {
 									<td>@createdBy.get.name</td>

--- a/app/views/projects/versions/log.scala.html
+++ b/app/views/projects/versions/log.scala.html
@@ -42,7 +42,7 @@
 							@visibilityChanges.reverse.map { case (entry, createdBy) =>
 							<tr>
 								<td>@VisibilityTypes.withId(entry.visibility)</td>
-								<td>@prettifyDateAndTime(entry.createdAt.value))))</td>
+								<td>@prettifyDateAndTime(entry.createdAt.value)</td>
 								<td>@entry.renderComment()</td>
 								@if(createdBy.isDefined) {
 									<td>@createdBy.get.name</td>

--- a/app/views/projects/versions/view.scala.html
+++ b/app/views/projects/versions/view.scala.html
@@ -36,7 +36,7 @@
                     <a href="@routes.Users.showProjects(v.p.project.ownerName, None)">
                         <strong>@v.p.project.ownerName</strong>
                     </a>
-                    released this version on @prettifyDate(v.v.createdAt.get)
+                    released this version on @prettifyDate(v.v.createdAt.value)
                 </p>
 
                 <!-- Buttons -->

--- a/app/views/projects/versions/view.scala.html
+++ b/app/views/projects/versions/view.scala.html
@@ -135,7 +135,7 @@
                                         <span class="caret"></span>
                                     </button>
                                     <ul class="dropdown-menu" aria-labelledby="admin-version-actions">
-                                        <li><a href="@appRoutes.showLog(None, None, None, v.v.id, None, None, None)">User Action Logs</a></li>
+                                        <li><a href="@appRoutes.showLog(None, None, None, Some(v.v.id.value), None, None, None)">User Action Logs</a></li>
                                         @if(request.data.globalPerm(ReviewProjects)) {
                                             @if(v.v.visibility == VisibilityTypes.SoftDelete) {
                                                 <li><a href="#" data-toggle="modal" data-target="#modal-restore">Undo delete</a></li>

--- a/app/views/projects/view.scala.html
+++ b/app/views/projects/view.scala.html
@@ -248,7 +248,7 @@ Base template for Project overview.
                                             Staff notes (@p.noteCount) </a></li>
                                     }
                                     @if(request.data.globalPerm(ViewLogs)) {
-                                        <li><a href="@appRoutes.showLog(None, None, p.project.id, None, None, None, None)">
+                                        <li><a href="@appRoutes.showLog(None, None, Some(p.project.id.value), None, None, None, None)">
                                             User Action Logs</a></li>
                                     }
                                     @if(request.data.globalPerm(ViewLogs)) {

--- a/app/views/users/admin/activity.scala.html
+++ b/app/views/users/admin/activity.scala.html
@@ -39,7 +39,7 @@
                                         <td>@prettifyDateAndTime(tuple._1.asInstanceOf[Review].endedAt.getOrElse(Timestamp.from(Instant.EPOCH)))</td>
                                         <td>for:
                                             @if(tuple._2.isDefined) {
-                                                <a href="@controllers.routes.Reviews.showReviews(tuple._2.get.ownerName, tuple._2.get.slug, tuple._1.asInstanceOf[Review].id.getOrElse(-1).toString)">
+                                                <a href="@controllers.routes.Reviews.showReviews(tuple._2.get.ownerName, tuple._2.get.slug, tuple._1.asInstanceOf[Review].id.value.toString)">
                                                     @tuple._2.get.ownerName / @tuple._2.get.name
                                                 </a>
                                             }

--- a/app/views/users/admin/flags.scala.html
+++ b/app/views/users/admin/flags.scala.html
@@ -29,7 +29,7 @@
             <div class="col-md-12">
                 <ul class="list-group list-flags-admin">
                     @flags.map { case (flag, user, project, projectPerm) =>
-                        <li data-flag-id="@flag.id.get" class="list-group-item">
+                        <li data-flag-id="@flag.id.value" class="list-group-item">
                             <div class="row">
                                 <div class="col-xs-12 col-md-1" style="width: 40px;">
                                     <a href="@routes.Users.showProjects(user.username, None)">

--- a/app/views/users/admin/log.scala.html
+++ b/app/views/users/admin/log.scala.html
@@ -74,7 +74,7 @@
                                     @if(canViewIP) {
                                         <td>@action.address.value</td>
                                     }
-                                    <td>@prettifyDateAndTime(action.createdAt.getOrElse(Timestamp.from(Instant.EPOCH)))</td>
+                                    <td>@prettifyDateAndTime(action.createdAt.value)))</td>
                                     <td>
                                         @action.action
                                         <small class="filter-action">(<a href="@appRoutes.showLog(Some(page), userFilter, projectFilter, versionFilter, pageFilter, Some(action.action.value), subjectFilter)">@action.action.value</a>)</small>

--- a/app/views/users/admin/log.scala.html
+++ b/app/views/users/admin/log.scala.html
@@ -74,7 +74,7 @@
                                     @if(canViewIP) {
                                         <td>@action.address.value</td>
                                     }
-                                    <td>@prettifyDateAndTime(action.createdAt.value)))</td>
+                                    <td>@prettifyDateAndTime(action.createdAt.value)</td>
                                     <td>
                                         @action.action
                                         <small class="filter-action">(<a href="@appRoutes.showLog(Some(page), userFilter, projectFilter, versionFilter, pageFilter, Some(action.action.value), subjectFilter)">@action.action.value</a>)</small>

--- a/app/views/users/admin/queue.scala.html
+++ b/app/views/users/admin/queue.scala.html
@@ -71,7 +71,7 @@
                                         Unknown
                                     }
                                     <br>
-                                    @prettifyDateAndTime(version.createdAt.get)
+                                    @prettifyDateAndTime(version.createdAt.value)
                                 </td>
                                 <td style="text-align: right; max-width: 40px">
                                 @if(unfinishedReview) {
@@ -88,11 +88,11 @@
                                 @if(unfinishedReview) {
                                     @reviewer
                                     <br>
-                                    <span data-ago="@review.createdAt.getOrElse(Timestamp.from(Instant.now())).getTime" data-title="started "></span>
+                                    <span data-ago="@review.createdAt.value.getTime" data-title="started "></span>
                                 } else {
                                     <strike>@reviewer</strike>
                                     <br>
-                                    <span data-ago="@review.createdAt.getOrElse(Timestamp.from(Instant.now())).getTime" data-title="abandoned "></span>
+                                    <span data-ago="@review.createdAt.value.getTime" data-title="abandoned "></span>
                                 }
                                 </td>
                                 <td style="vertical-align: middle; text-align: right; padding-right: 15px;">
@@ -136,7 +136,7 @@
                                 </th>
                             </tr>
                         }
-                        @versions.sortWith(_._2.createdAt.get.getTime < _._2.createdAt.get.getTime).map { case (project, version, channel, author, projectOwner) =>
+                        @versions.sortWith(_._2.createdAt.value.getTime < _._2.createdAt.value.getTime).map { case (project, version, channel, author, projectOwner) =>
                             <tr data-version="@helper.urlEncode(project.ownerName)/@helper.urlEncode(project.slug)/versions/@helper.urlEncode(version.name)">
                                 <td>
                                     @userAvatar(Some(projectOwner.name), projectOwner.avatarUrl, clazz = "user-avatar-xs")
@@ -147,7 +147,7 @@
                                     </a>
                                 </td>
                                 <td>
-                                    <span class="faint">@prettifyDate(version.createdAt.get)</span>
+                                    <span class="faint">@prettifyDate(version.createdAt.value)</span>
                                     <span class="minor">@version.versionString</span>
                                     <span class="channel" style="background-color: @channel.color.hex;">@channel.name</span>
                                 </td>

--- a/app/views/users/admin/reviews.scala.html
+++ b/app/views/users/admin/reviews.scala.html
@@ -25,7 +25,7 @@
                     <a href="@routes.Users.showProjects(project.ownerName, None)">
                         <strong>@project.ownerName</strong>
                     </a>
-                    released this version on @prettifyDate(version.createdAt.get)
+                    released this version on @prettifyDate(version.createdAt.value)
                 </p>
                 @if(!version.isReviewed) {
                     <div class="pull-right">
@@ -88,7 +88,7 @@
                         @reviews.reverse.zipWithIndex.map { case ((item, name), index) =>
                             @if(item.endedAt.isDefined) {
                                 @if(reviews.size > (reviews.size-index)) {
-                                    @if(prettifyDateAndTime(item.endedAt.get).equalsIgnoreCase(prettifyDateAndTime(reviews.reverse(reviews.size - index - 1)._1.createdAt.get))) {
+                                    @if(prettifyDateAndTime(item.endedAt.get).equalsIgnoreCase(prettifyDateAndTime(reviews.reverse(reviews.size - index - 1)._1.createdAt.value))) {
                                         <tr>
                                             <td>@prettifyDateAndTime(item.endedAt.get)</td>
                                             <td>
@@ -144,7 +144,7 @@
                                 </tr>
                             }
                             <tr>
-                                <td>@prettifyDateAndTime(item.createdAt.get)</td>
+                                <td>@prettifyDateAndTime(item.createdAt.value)</td>
                                 <td><strong>@name.getOrElse("Unknown")</strong> started a review</td>
                             </tr>
                         }

--- a/app/views/users/admin/visibility.scala.html
+++ b/app/views/users/admin/visibility.scala.html
@@ -36,7 +36,7 @@
                             </li>
                         }
                         @needsApproval.map { case (project, projectPerms, lastChangeRequest, lastChangeRequester, lastVisibilityChange, lastVisibilityChanger) =>
-                            <li data-flag-id="@project.id.get" class="list-group-item">
+                            <li data-flag-id="@project.id.value" class="list-group-item">
                                 <div class="row">
                                     <div class="col-xs-12 col-md-8">
                                         @if(lastChangeRequest.isDefined) {
@@ -100,7 +100,7 @@
                         }
                         @waitingProjects.map { case (project, lastChangeRequest, lastVisibilityChange, lastVisibilityChanger) =>
                             @lastChangeRequest.map { lastRequest =>
-                                <li data-flag-id="@project.id.get" class="list-group-item">
+                                <li data-flag-id="@project.id.value" class="list-group-item">
                                     <div class="row">
                                         <div class="col-xs-12">
                                             <span class="description">

--- a/app/views/users/authors.scala.html
+++ b/app/views/users/authors.scala.html
@@ -70,7 +70,7 @@
                               }
 
                           </td>
-                          <td>@prettifyDate(user.joinDate.getOrElse(user.createdAt.get))</td>
+                          <td>@prettifyDate(user.joinDate.getOrElse(user.createdAt.value))</td>
                           <td>@projectCount</td>
                       </tr>
                     }

--- a/app/views/users/invite/form.scala.html
+++ b/app/views/users/invite/form.scala.html
@@ -45,7 +45,7 @@
             @loadedUsers.map { user =>
                 <tr>
                     <td>
-                        <input form="form-continue" type="hidden" value="@user.id.get" />
+                        <input form="form-continue" type="hidden" value="@user.id.value" />
                         @userAvatar(Some(user.name), user.avatarUrl, clazz = "user-avatar-xs")
                         <a target="_blank" rel="noopener" href="@routes.Users.showProjects(user.username, None)">
                             @user.username

--- a/app/views/users/memberList.scala.html
+++ b/app/views/users/memberList.scala.html
@@ -100,9 +100,7 @@
                 <a class="username" href="@routes.Users.showProjects(user.username, None)">
                 @user.username
                 </a>
-                    @role.id.map { id =>
-                        <p style="display: none;" class="role-id">@id</p>
-                    }
+                    <p style="display: none;" class="role-id">@role.id.value</p>
                     @if(editable && perms.getOrElse(EditSettings, false) && !role.roleType.trust.equals(Absolute)) {
                         <a href="#">
                             <i style="padding-left:5px" class="fa fa-trash" data-toggle="modal" data-target="#modal-user-delete"></i>

--- a/app/views/users/notifications.scala.html
+++ b/app/views/users/notifications.scala.html
@@ -78,7 +78,7 @@
                         <ul class="list-group">
                         @notifications.map { case (notification, origin) =>
                             <li class="list-group-item notification" data-action="@notification.action.getOrElse("none")"
-                            data-id="@notification.id.get">
+                            data-id="@notification.id.value">
 
                                 @userAvatar(Some(origin.name), origin.avatarUrl, clazz = "user-avatar-s")
                                 @formatNotification(notification)
@@ -120,7 +120,7 @@
                             }
 
                         <div class="invite col-xs-12 col-md-6">
-                            <div class="invite-content" data-id="@invite.id.get"
+                            <div class="invite-content" data-id="@invite.id.value"
                             data-type="@subject.getClass.getSimpleName.toLowerCase">
                                 <span class="minor">
                                     <i class="dismiss pull-left fa fa-times" style="display: none;"></i>

--- a/app/views/users/staff.scala.html
+++ b/app/views/users/staff.scala.html
@@ -57,7 +57,7 @@
 							}
 
 						</td>
-						<td>@prettifyDate(user.joinDate.getOrElse(user.createdAt.get))</td>
+						<td>@prettifyDate(user.joinDate.getOrElse(user.createdAt.value))</td>
 					</tr>
 					}
 

--- a/app/views/users/view.scala.html
+++ b/app/views/users/view.scala.html
@@ -150,7 +150,7 @@
                     <i class="minor">
                     @messages(
                         "user.memberSince",
-                        u.user.joinDate.map(prettifyDate).getOrElse(prettifyDate(u.user.createdAt.get)))
+                        u.user.joinDate.map(prettifyDate).getOrElse(prettifyDate(u.user.createdAt.value)))
                     </i><br/>
                     <a href="https://forums.spongepowered.org/users/@u.user.username">
                         @messages("user.viewOnForums") <i class="fa fa-external-link"></i>

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "javax.mail"            %   "mail"                    %   "1.4.7",
   "com.beachape"          %%  "enumeratum"              %   "1.5.13",
   "com.beachape"          %%  "enumeratum-slick"        %   "1.5.15",
-  "com.chuusai"           %% "shapeless"                %   "2.3.3",
+  "com.chuusai"           %%  "shapeless"               %   "2.3.3",
 
   "com.vladsch.flexmark"  % "flexmark"                       %  "0.34.22",
   "com.vladsch.flexmark"  % "flexmark-ext-autolink"          %  "0.34.22",

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ libraryDependencies ++= Seq(
   "javax.mail"            %   "mail"                    %   "1.4.7",
   "com.beachape"          %%  "enumeratum"              %   "1.5.13",
   "com.beachape"          %%  "enumeratum-slick"        %   "1.5.15",
+  "com.chuusai"           %% "shapeless"                %   "2.3.3",
 
   "com.vladsch.flexmark"  % "flexmark"                       %  "0.34.22",
   "com.vladsch.flexmark"  % "flexmark-ext-autolink"          %  "0.34.22",


### PR DESCRIPTION
Replaces Option ids and timestamps with custom types. This is done as those two values are 99% of the time not optional, and instead something the DB is responsible for filling out. This PR also aims to drop support for data that is in the wrong configuration. If an object id is missing, an exception is generated instead of possibly creating invalid data.

Another addition is the type `ObjectReference`. It's intended to be used for all sorts of object ids. At the moment it's just aliased to Int, but in the future it would be great if it could be made opaque.

For the most part I expect stuff to work as it used to. `Tag` needs to be tested as they have no creation date. `Review` also does some funky stuff with the `createdAt` field so it needs to be tested too. I'll hopefully get around to testing it once I get back to my main computer.

As for the typelevel programming stuff in the schema, I've tried to make it as understandable as possible. Tell me if there is still some stuff that isn't completely clear. Technically Akka ships with a shaded shapeless, but I don't think it's wise to use that as it's probably regarded as internal.