### PR TITLE
Rewrite Metadata Ripper to support multiple types of files, and add Mixin Tag

### DIFF
--- a/app/controllers/project/Projects.scala
+++ b/app/controllers/project/Projects.scala
@@ -162,7 +162,7 @@ class Projects @Inject()(stats: StatTracker,
                 this.cache.set(namespace + '/' + version.underlying.versionString, version)
                 implicit val currentUser: User = request.user
 
-                val authors = pendingProject.file.data.get.getAuthors.toList
+                val authors = pendingProject.file.data.get.authors.toList
                 (
                   Future.sequence(authors.filterNot(_.equals(currentUser.username)).map(this.users.withName(_).value)),
                   this.forums.countUsers(authors),

--- a/app/controllers/project/Projects.scala
+++ b/app/controllers/project/Projects.scala
@@ -99,12 +99,12 @@ class Projects @Inject()(stats: StatTracker,
             try {
               val plugin = this.factory.processPluginUpload(uploadData, user)
               plugin match {
-                case Left(pluginFile) =>
+                case Right(pluginFile) =>
                   val project = this.factory.startProject(pluginFile)
                   project.cache()
                   val model = project.underlying
                   Redirect(self.showCreatorWithMeta(model.ownerName, model.slug))
-                case Right(errorMessage) =>
+                case Left(errorMessage) =>
                   Redirect(self.showCreator()).withError(errorMessage)
               }
             } catch {
@@ -162,7 +162,7 @@ class Projects @Inject()(stats: StatTracker,
                 this.cache.set(namespace + '/' + version.underlying.versionString, version)
                 implicit val currentUser: User = request.user
 
-                val authors = pendingProject.file.data.get.getAuthors
+                val authors = pendingProject.file.data.get.getAuthors.toList
                 (
                   Future.sequence(authors.filterNot(_.equals(currentUser.username)).map(this.users.withName(_).value)),
                   this.forums.countUsers(authors),

--- a/app/controllers/project/Projects.scala
+++ b/app/controllers/project/Projects.scala
@@ -98,10 +98,15 @@ class Projects @Inject()(stats: StatTracker,
           case Some(uploadData) =>
             try {
               val plugin = this.factory.processPluginUpload(uploadData, user)
-              val project = this.factory.startProject(plugin)
-              project.cache()
-              val model = project.underlying
-              Redirect(self.showCreatorWithMeta(model.ownerName, model.slug))
+              plugin match {
+                case Left(pluginFile) =>
+                  val project = this.factory.startProject(pluginFile)
+                  project.cache()
+                  val model = project.underlying
+                  Redirect(self.showCreatorWithMeta(model.ownerName, model.slug))
+                case Right(errorMessage) =>
+                  Redirect(self.showCreator()).withError(errorMessage)
+              }
             } catch {
               case e: InvalidPluginFileException =>
                 Redirect(self.showCreator()).withErrors(Option(e.getMessage).toList)
@@ -157,13 +162,13 @@ class Projects @Inject()(stats: StatTracker,
                 this.cache.set(namespace + '/' + version.underlying.versionString, version)
                 implicit val currentUser: User = request.user
 
-                val authors = pendingProject.file.meta.get.getAuthors.asScala
+                val authors = pendingProject.file.data.get.getAuthors
                 (
                   Future.sequence(authors.filterNot(_.equals(currentUser.username)).map(this.users.withName(_).value)),
-                  this.forums.countUsers(authors.toList),
+                  this.forums.countUsers(authors),
                   pendingProject.underlying.owner.user
                 ).parMapN { (users, registered, owner) =>
-                  Ok(views.invite(owner, pendingProject, users.flatten.toList, registered))
+                  Ok(views.invite(owner, pendingProject, users.flatten, registered))
                 }
               }
             )

--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -229,16 +229,9 @@ class Versions @Inject()(stats: StatTracker,
       .flatMap(_ => PluginUpload.bindFromRequest().toRight(Redirect(call).withError("error.noFile")))
 
     EitherT.fromEither[Future](uploadData).flatMap { data =>
-      //TODO: We should get rid of this try
-      try {
-        this.factory
-          .processSubsequentPluginUpload(data, user, request.data.project)
-          .leftMap(err => Redirect(call).withError(err))
-      }
-      catch {
-        case e: InvalidPluginFileException =>
-          EitherT.leftT[Future, PendingVersion](Redirect(call).withErrors(Option(e.getMessage).toList))
-      }
+      this.factory
+        .processSubsequentPluginUpload(data, user, request.data.project)
+        .leftMap(err => Redirect(call).withError(err))
     }.map { pendingVersion =>
       pendingVersion.underlying.setAuthorId(user.id.getOrElse(-1))
       Redirect(self.showCreatorWithMeta(request.data.project.ownerName, slug, pendingVersion.underlying.versionString))

--- a/app/models/project/Tag.scala
+++ b/app/models/project/Tag.scala
@@ -63,7 +63,7 @@ object TagColors extends Enumeration {
   val SpongeVanilla = TagColor(5, "#50C888", "#FFFFFF")
   val SpongeCommon = TagColor(6, "#5d5dff", "#FFFFFF")
   val Lantern = TagColor(7, "#4EC1B4", "#FFFFFF")
-  val Mixin = TagColor(8, "#F4803D", "#FFFFFF")
+  val Mixin = TagColor(8, "#FFA500", "#333333")
 
   def withId(id: Int): TagColor = {
     this.apply(id).asInstanceOf[TagColor]

--- a/app/models/project/Tag.scala
+++ b/app/models/project/Tag.scala
@@ -63,6 +63,7 @@ object TagColors extends Enumeration {
   val SpongeVanilla = TagColor(5, "#50C888", "#FFFFFF")
   val SpongeCommon = TagColor(6, "#5d5dff", "#FFFFFF")
   val Lantern = TagColor(7, "#4EC1B4", "#FFFFFF")
+  val Mixin = TagColor(8, "#F4803D", "#FFFFFF")
 
   def withId(id: Int): TagColor = {
     this.apply(id).asInstanceOf[TagColor]

--- a/app/models/project/Version.scala
+++ b/app/models/project/Version.scala
@@ -208,7 +208,7 @@ case class Version(override val id: Option[Int] = None,
   def dependencies: List[Dependency] = {
     for (depend <- this.dependencyIds) yield {
       val data = depend.split(":")
-      Dependency(data(0), data(1))
+      Dependency(data(0), if (data.length > 1) data(1) else "")
     }
   }
 

--- a/app/ore/project/factory/PendingProject.scala
+++ b/app/ore/project/factory/PendingProject.scala
@@ -37,10 +37,15 @@ case class PendingProject(projects: ProjectBase,
     * The first [[PendingVersion]] for this PendingProject.
     */
   val pendingVersion: PendingVersion = {
-    val version = this.factory.startVersion(this.file, this.underlying, this.settings, this.channelName)
-    val model = version.underlying
-    version.cache()
-    version
+    val result = this.factory.startVersion(this.file, this.underlying, this.settings, this.channelName)
+    result match {
+      case Left (version) =>
+        val model = version.underlying
+        version.cache()
+        version
+        // TODO: not this crap
+      case Right (errorMessage) => throw new IllegalArgumentException(errorMessage)
+    }
   }
 
   def complete()(implicit ec: ExecutionContext): Future[(Project, Version)] = {

--- a/app/ore/project/factory/PendingProject.scala
+++ b/app/ore/project/factory/PendingProject.scala
@@ -39,12 +39,12 @@ case class PendingProject(projects: ProjectBase,
   val pendingVersion: PendingVersion = {
     val result = this.factory.startVersion(this.file, this.underlying, this.settings, this.channelName)
     result match {
-      case Left (version) =>
+      case Right (version) =>
         val model = version.underlying
         version.cache()
         version
         // TODO: not this crap
-      case Right (errorMessage) => throw new IllegalArgumentException(errorMessage)
+      case Left (errorMessage) => throw new IllegalArgumentException(errorMessage)
     }
   }
 

--- a/app/ore/project/factory/ProjectFactory.scala
+++ b/app/ore/project/factory/ProjectFactory.scala
@@ -206,7 +206,7 @@ trait ProjectFactory {
     val path = plugin.path
     val version = Version.Builder(this.service)
       .versionString(metaData.getVersion.get)
-      .dependencyIds(metaData.getDependencies.map(d => d.pluginId + ":" + d.version))
+      .dependencyIds(metaData.getDependencies.map(d => d.pluginId + ":" + d.version).toList)
       .description(metaData.get[String]("description").getOrElse(""))
       .projectId(project.id.getOrElse(-1)) // Version might be for an uncreated project
       .fileSize(path.toFile.length)

--- a/app/ore/project/io/PluginFile.scala
+++ b/app/ore/project/io/PluginFile.scala
@@ -9,10 +9,8 @@ import com.google.common.base.Preconditions._
 import models.user.User
 import ore.user.UserOwned
 import org.apache.commons.codec.digest.DigestUtils
-import org.spongepowered.plugin.meta.{McModInfo, PluginMetadata}
 
 import play.api.i18n.Messages
-import scala.collection.JavaConverters._
 import scala.util.control.Breaks._
 
 /**
@@ -21,9 +19,6 @@ import scala.util.control.Breaks._
   * @param _path Path to uploaded file
   */
 class PluginFile(private var _path: Path, val signaturePath: Path, val user: User) extends UserOwned {
-
-  private val MetaFileName = "mcmod.info"
-  private val ManifestFileName = "META-INF/MANIFEST.MF"
 
   private var _data: Option[PluginFileData] = None
   private var _md5: String = _

--- a/app/ore/project/io/PluginFile.scala
+++ b/app/ore/project/io/PluginFile.scala
@@ -80,7 +80,7 @@ class PluginFile(private var _path: Path, val signaturePath: Path, val user: Use
     */
   @throws[InvalidPluginFileException]
   def loadMeta()(implicit messages: Messages): Either[String, PluginFileData] = {
-    val fileNames = PluginFileData.getFileNames
+    val fileNames = PluginFileData.fileNames
 
     var jarIn: JarInputStream = null
     try {

--- a/app/ore/project/io/PluginFileData.scala
+++ b/app/ore/project/io/PluginFileData.scala
@@ -1,0 +1,186 @@
+package ore.project.io
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.util.jar.{JarEntry, JarInputStream}
+
+import com.google.gson.{JsonElement, JsonParser}
+import com.google.gson.stream.JsonReader
+import ore.project.Dependency
+import org.spongepowered.plugin.meta.PluginMetadata
+
+import scala.collection.mutable.ListBuffer
+
+/**
+  * The metadata within a [[PluginFile]]
+  *
+  * @author phase
+  * @param data the data within a [[PluginFile]]
+  */
+class PluginFileData(data: List[DataValue[_]]) {
+
+  def getId: Option[String] = {
+    get[String]("id")
+  }
+
+  def getVersion: Option[String] = {
+    get[String]("version")
+  }
+
+  def getAuthors: List[String] = {
+    get[List[String]]("authors").getOrElse(List())
+  }
+
+  def getDependencies: List[Dependency] = {
+    get[List[Dependency]]("dependencies").getOrElse(List())
+  }
+
+  def get[T](key: String): Option[T] = {
+    data.filter(_.key == key).filter(_.isInstanceOf[DataValue[T]]).map(_.asInstanceOf[DataValue[T]].value).headOption
+  }
+
+  def isValidPlugin: Boolean = {
+    data.exists(_.isInstanceOf[StringDataValue]) &&
+      data.exists(_.isInstanceOf[StringDataValue])
+  }
+
+  /**
+    * A mod using Mixins will contain the "MixinConfigs" attribute in their MANIFEST
+    *
+    * @return
+    */
+  def containsMixins: Boolean = {
+    data.exists(p => p.key == "MixinConfigs" && p.value.isInstanceOf[StringDataValue])
+  }
+
+}
+
+object PluginFileData {
+  val fileTypes: List[FileType] = List(ModInfo, Manifest, ModToml)
+
+  def getFileNames: List[String] = fileTypes.map(_.fileName).distinct
+
+  def getData(fileName: String, jarInputStream: JarInputStream): List[DataValue[_]] = {
+    val stream = new BufferedReader(new InputStreamReader(jarInputStream))
+    fileTypes.filter(_.fileName == fileName).flatMap(_.getData(stream))
+  }
+
+}
+
+/**
+  * A data element in a data file
+  *
+  * @param key   the key for the value
+  * @param value the value extracted from the file
+  * @tparam T the type of the value
+  */
+sealed class DataValue[T](val key: String, val value: T)
+
+/**
+  * A data element that is a String, such as the plugin id or version
+  *
+  * @param value the value extracted from the file
+  */
+case class StringDataValue(override val key: String, override val value: String)
+  extends DataValue[String](key, value)
+
+/**
+  * A data element that is a list of strings, such as an authors list
+  *
+  * @param value the value extracted from the file
+  */
+case class StringListValue(override val key: String, override val value: List[String])
+  extends DataValue[List[String]](key, value)
+
+/**
+  * A data element that is a list of [[Dependency]]
+  *
+  * @param value the value extracted from the file
+  */
+case class DependencyDataValue(override val key: String, override val value: List[Dependency])
+  extends DataValue[List[Dependency]](key, value)
+
+sealed abstract case class FileType(fileName: String) {
+  def getData(bufferedReader: BufferedReader): List[DataValue[_]]
+}
+
+object ModInfo extends FileType("mcmod.info") {
+  override def getData(bufferedReader: BufferedReader): List[DataValue[_]] = {
+    //    val lines = Stream.continually(bufferedReader.readLine()).takeWhile(_ != null)
+    //    lines.foreach(println)
+
+    val dataValues = new ListBuffer[DataValue[_]]
+
+    try {
+      val parser = new JsonParser().parse(new JsonReader(bufferedReader))
+      println(parser.toString)
+
+      val modArray = parser.getAsJsonArray
+      for (i <- 0 until modArray.size()) {
+        val modObject = modArray.get(i).getAsJsonObject
+
+        // collect members
+
+        if (modObject.has("modid"))
+          dataValues += StringDataValue("id", modObject.get("modid").getAsString)
+        if (modObject.has("name"))
+          dataValues += StringDataValue("name", modObject.get("name").getAsString)
+        if (modObject.has("version"))
+          dataValues += StringDataValue("version", modObject.get("version").getAsString)
+        if (modObject.has("description"))
+          dataValues += StringDataValue("description", modObject.get("description").getAsString)
+        if (modObject.has("url"))
+          dataValues += StringDataValue("url", modObject.get("url").getAsString)
+
+        if (modObject.has("authors")) {
+          val authors = new ListBuffer[String]
+          val authorsJson = modObject.getAsJsonArray("authors")
+          for (j <- 0 until authorsJson.size()) {
+            val element = authorsJson.get(j)
+            authors += element.getAsString
+          }
+          dataValues += StringListValue("authors", authors.toList)
+        }
+
+        // collect dependencies
+
+        val dependencies = new ListBuffer[Dependency]
+
+        if (modObject.has("requiredMods")) {
+          val dependenciesJson = modObject.getAsJsonArray("requiredMods")
+          for (j <- 0 until dependenciesJson.size()) {
+            var dependencyId = ""
+            var dependencyVersion = ""
+
+            val dependencyJson = dependenciesJson.get(j)
+            val parts = dependencyJson.getAsString.split("@")
+            if (parts.nonEmpty) {
+              dependencyId = parts(0)
+            }
+            if (parts.length > 1) {
+              dependencyVersion = parts(1)
+            }
+
+            if (dependencyId != null && !dependencyId.isEmpty) {
+              dependencies += Dependency(dependencyId, dependencyVersion)
+            }
+          }
+        }
+
+        dataValues += DependencyDataValue("dependencies", dependencies.toList)
+      }
+      println(dataValues.toList)
+    } catch {
+      case e: Exception => e.printStackTrace()
+    }
+
+    dataValues.toList
+  }
+}
+
+object Manifest extends FileType("META-INF/MANIFEST.MF") {
+  override def getData(bufferedReader: BufferedReader): List[DataValue[_]] = ???
+}
+
+object ModToml extends FileType("mod.toml") {
+  override def getData(bufferedReader: BufferedReader): List[DataValue[_]] = ???
+}

--- a/app/ore/project/io/PluginFileData.scala
+++ b/app/ore/project/io/PluginFileData.scala
@@ -2,13 +2,11 @@ package ore.project.io
 
 import java.io.BufferedReader
 
-import com.google.gson.JsonParser
-import com.google.gson.stream.JsonReader
 import models.project.{Tag, TagColors}
 import ore.project.Dependency
 import org.spongepowered.plugin.meta.McModInfo
-import scala.collection.JavaConverters._
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 /**
@@ -27,19 +25,19 @@ class PluginFileData(data: Seq[DataValue[_]]) {
     } else value
   }.toSeq
 
-  def getId: Option[String] = {
+  def id: Option[String] = {
     get[String]("id")
   }
 
-  def getVersion: Option[String] = {
+  def version: Option[String] = {
     get[String]("version")
   }
 
-  def getAuthors: Seq[String] = {
+  def authors: Seq[String] = {
     get[Seq[String]]("authors").getOrElse(Seq())
   }
 
-  def getDependencies: Seq[Dependency] = {
+  def dependencies: Seq[Dependency] = {
     get[Seq[Dependency]]("dependencies").getOrElse(Seq())
   }
 
@@ -52,7 +50,7 @@ class PluginFileData(data: Seq[DataValue[_]]) {
       dataValues.exists(_.isInstanceOf[StringDataValue])
   }
 
-  def getGhostTags: Seq[Tag] = {
+  def ghostTags: Seq[Tag] = {
     val buffer = new ArrayBuffer[Tag]
 
     if (containsMixins) {
@@ -78,7 +76,7 @@ class PluginFileData(data: Seq[DataValue[_]]) {
 object PluginFileData {
   val fileTypes: Seq[FileTypeHandler] = Seq(McModInfoHandler, ManifestHandler, ModTomlHandler)
 
-  def getFileNames: Seq[String] = fileTypes.map(_.fileName).distinct
+  def fileNames: Seq[String] = fileTypes.map(_.fileName).distinct
 
   def getData(fileName: String, stream: BufferedReader): Seq[DataValue[_]] = {
     fileTypes.filter(_.fileName == fileName).flatMap(_.getData(stream))


### PR DESCRIPTION
![](https://cdn.discordapp.com/attachments/468560985171427329/480935758652243968/2018-08-19-200632_1920x1080_scrot.png)

The old system was completely reliant on Sponge's `mcmod.info` parser.
We can't rely on Sponge's implementation because it'll probably be removed once
1.13 comes out. It has been replaced with a more generic metadata system that can
work for any type of file, as long as there is a parser for it.

`PluginFileData` contains a list of `DataValue`s that have different meta about
the project. The majority of it is platform agnostic, such as plugin id &
version, but some things are super specific like `MixinConfigs` being present in
the `MANIFEST.MF`. The system supports all kinds of data, and migrating to the
Forge 1.13 TOML format will take plugging in a TOML parser. This opens the door
to other parsing other platform metadata files like BungeeCoord's `bungee.yml`.

Dependency parsing is a little different now since we're not relying on Sponge's 
parser. It's essentially the same, except dependencies are parsed into the
`PluginFileData` and then put into the `Version` when it is constructed.
This is important to note for future platforms that don't have a `requiredMods`
section. All you would need to do is add a dependency list within your file 
handler. So at the top of the `bungee.yml` handler, slap a `DependencyDataValue`
containing the platform. The platform will get parsed into a tag later in the
process.

This PR relies on the `feature/sf-tags` branch. If that is merged in first then
we can just change the base branch of this PR.

Closes #247 
References #527 
References #510 
