### PR TITLE
Make MembershipDossier a typeclass

### DIFF
--- a/app/db/impl/access/OrganizationBase.scala
+++ b/app/db/impl/access/OrganizationBase.scala
@@ -70,6 +70,7 @@ class OrganizationBase(implicit val service: ModelService, config: OreConfig) ex
           _       <- service.update(userOrg.copy(globalRoles = RoleType.Organization :: userOrg.globalRoles))
           _ <- // Add the owner
           org.memberships.addRole(
+            org,
             OrganizationRole(
               userId = ownerId,
               organizationId = org.id.value,
@@ -83,7 +84,7 @@ class OrganizationBase(implicit val service: ModelService, config: OreConfig) ex
 
             Future.sequence(members.map { role =>
               // TODO remove role.user db access we really only need the userid we already have for notifications
-              org.memberships.addRole(role.copy(organizationId = org.id.value)).flatMap(_ => role.user).flatMap {
+              org.memberships.addRole(org, role.copy(organizationId = org.id.value)).flatMap(_ => role.user).flatMap {
                 user =>
                   user.sendNotification(
                     Notification(

--- a/app/models/viewhelper/OrganizationData.scala
+++ b/app/models/viewhelper/OrganizationData.scala
@@ -39,7 +39,7 @@ object OrganizationData {
       service: ModelService
   ): Future[OrganizationData] =
     for {
-      members      <- orga.memberships.members
+      members      <- orga.memberships.members(orga)
       memberRoles  <- Future.traverse(members)(_.headRole)
       memberUser   <- Future.traverse(memberRoles)(_.user)
       projectRoles <- db.run(queryProjectRoles(orga.id.value).result)

--- a/app/ore/Joinable.scala
+++ b/app/ore/Joinable.scala
@@ -31,6 +31,6 @@ trait Joinable[M <: Member[_ <: RoleModel], Self <: Model] extends ScopeSubject 
     *
     * @return Memberships
     */
-  def memberships(implicit service: ModelService): MembershipDossier[Self]
+  def memberships(implicit ec: ExecutionContext, service: ModelService): MembershipDossier[Future, Self]
 
 }

--- a/app/ore/organization/OrganizationMember.scala
+++ b/app/ore/organization/OrganizationMember.scala
@@ -2,7 +2,6 @@ package ore.organization
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import db.impl.access.UserBase
 import db.{ModelService, ObjectReference}
 import models.user.Organization
 import models.user.role.OrganizationRole
@@ -14,13 +13,11 @@ import ore.user.Member
   *
   * @param organization Organization member belongs to
   * @param userId       User ID
-  * @param users        UserBase instance
   */
-class OrganizationMember(val organization: Organization, override val userId: ObjectReference)(implicit users: UserBase)
-    extends Member[OrganizationRole](userId) {
+class OrganizationMember(val organization: Organization, val userId: ObjectReference) extends Member[OrganizationRole] {
 
   override def roles(implicit ec: ExecutionContext, service: ModelService): Future[Set[OrganizationRole]] =
-    this.user.flatMap(user => this.organization.memberships.getRoles(user))
+    this.user.flatMap(user => this.organization.memberships.getRoles(organization, user))
 
   override def scope: Scope = this.organization.scope
 

--- a/app/ore/project/ProjectMember.scala
+++ b/app/ore/project/ProjectMember.scala
@@ -2,7 +2,6 @@ package ore.project
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import db.impl.access.UserBase
 import db.{ModelService, ObjectReference}
 import models.project.Project
 import models.user.role.ProjectRole
@@ -15,11 +14,10 @@ import ore.user.Member
   * @param project  Project this Member is a part of
   * @param userId   Member user ID
   */
-class ProjectMember(val project: Project, override val userId: ObjectReference)(implicit users: UserBase)
-    extends Member[ProjectRole](userId) {
+class ProjectMember(val project: Project, val userId: ObjectReference) extends Member[ProjectRole] {
 
   override def roles(implicit ec: ExecutionContext, service: ModelService): Future[Set[ProjectRole]] =
-    this.user.flatMap(user => this.project.memberships.getRoles(user))
+    this.user.flatMap(user => this.project.memberships.getRoles(project, user))
   override val scope: Scope = this.project.scope
 
   /**

--- a/app/ore/project/factory/ProjectFactory.scala
+++ b/app/ore/project/factory/ProjectFactory.scala
@@ -14,16 +14,14 @@ import play.api.i18n.Messages
 
 import db.ModelService
 import db.impl.access.ProjectBase
-import db.impl.schema.{ProjectMembersTable, ProjectRoleTable}
 import discourse.OreDiscourseApi
 import models.project._
 import models.user.role.ProjectRole
 import models.user.{Notification, User}
 import ore.permission.role.RoleType
+import ore.project.NotifyWatchersTask
 import ore.project.factory.TagAlias.ProjectTag
 import ore.project.io._
-import ore.project.{NotifyWatchersTask, ProjectMember}
-import ore.user.MembershipDossier
 import ore.user.notification.NotificationType
 import ore.{Color, OreConfig, OreEnv, Platform}
 import security.pgp.PGPVerifier
@@ -290,21 +288,19 @@ trait ProjectFactory {
       _          <- newProject.updateSettings(pending.settings)
       _ <- {
         // Invite members
-        val dossier: MembershipDossier[Project] {
-          type MembersTable = ProjectMembersTable
-          type MemberType   = ProjectMember
-          type RoleTable    = ProjectRoleTable
-          type RoleType     = ProjectRole
-        }             = newProject.memberships
+        val dossier   = newProject.memberships
         val owner     = newProject.owner
         val ownerId   = owner.userId
         val projectId = newProject.id.value
 
         val addRole =
-          dossier.addRole(new ProjectRole(ownerId, RoleType.ProjectOwner, projectId, accepted = true, visible = true))
+          dossier.addRole(
+            newProject,
+            new ProjectRole(ownerId, RoleType.ProjectOwner, projectId, accepted = true, visible = true)
+          )
         val addOtherRoles = Future.traverse(pending.roles) { role =>
           role.user.flatMap { user =>
-            dossier.addRole(role.copy(projectId = projectId)) *>
+            dossier.addRole(newProject, role.copy(projectId = projectId)) *>
               user.sendNotification(
                 Notification(
                   userId = user.id.value,

--- a/app/ore/user/Member.scala
+++ b/app/ore/user/Member.scala
@@ -4,7 +4,7 @@ import scala.language.implicitConversions
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import db.{ModelService, ObjectReference}
+import db.ModelService
 import models.user.User
 import models.user.role.RoleModel
 import ore.permission.scope.ScopeSubject
@@ -12,7 +12,7 @@ import ore.permission.scope.ScopeSubject
 /**
   * Represents a [[User]] member of some entity.
   */
-abstract class Member[RoleType <: RoleModel](override val userId: ObjectReference) extends ScopeSubject with UserOwned {
+trait Member[RoleType <: RoleModel] extends ScopeSubject with UserOwned {
 
   /**
     * Returns the [[RoleModel]]s the user has in this entity.

--- a/app/ore/user/MembershipDossier.scala
+++ b/app/ore/user/MembershipDossier.scala
@@ -1,45 +1,41 @@
 package ore.user
 
-import scala.language.implicitConversions
+import scala.language.{higherKinds, implicitConversions}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import db.access.ModelAccess
 import db.impl.OrePostgresDriver.api._
+import db.impl.schema.{OrganizationMembersTable, ProjectMembersTable}
 import db.table.AssociativeTable
 import db.{Model, ModelService, ObjectReference}
-import models.user.User
-import models.user.role.RoleModel
-import ore.permission.role.Trust
+import models.project.Project
+import models.user.role.{OrganizationRole, ProjectRole, RoleModel}
+import models.user.{Organization, User}
+import ore.organization.OrganizationMember
+import ore.permission.role.{Default, Trust}
+import ore.project.ProjectMember
+
+import cats.instances.future._
+import cats.syntax.all._
 
 /**
   * Handles and keeps track of [[User]] "memberships" for an [[Model]].
   */
-abstract class MembershipDossier[ModelType <: Model](val model: ModelType) {
-
+trait MembershipDossier[F[_], M <: Model] {
   type RoleType <: RoleModel
   type MemberType <: Member[RoleType]
-  type MembersTable <: AssociativeTable
 
-  def roleClass: Class[RoleType]
-  def membersTableClass: Class[MembersTable]
+  def roles(model: M): ModelAccess[RoleType]
 
-  implicit def convertModel(model: ModelType): this.model.M = model.asInstanceOf[this.model.M]
-
-  def roles(implicit service: ModelService): ModelAccess[RoleType] =
-    this.model.schema.getChildren[RoleType](this.roleClass, this.model)
-
-  private def association(implicit service: ModelService) =
-    this.model.schema.getAssociation[MembersTable, User](this.membersTableClass, this.model)
-  def roleAccess(implicit service: ModelService): ModelAccess[RoleType]                   = service.access[RoleType](roleClass)
-  private def addMember(user: User)(implicit ec: ExecutionContext, service: ModelService) = this.association.add(user)
+  def roleAccess: ModelAccess[RoleType]
 
   /**
     * Clears the roles of a User
     *
     * @param user User instance
     */
-  def clearRoles(user: User): Future[Int]
+  def clearRoles(model: M, user: User): F[Int]
 
   /**
     * Constructs a new member object of the MemberType.
@@ -47,7 +43,7 @@ abstract class MembershipDossier[ModelType <: Model](val model: ModelType) {
     * @param userId User ID of member
     * @return       New Member
     */
-  def newMember(userId: ObjectReference)(implicit ec: ExecutionContext): MemberType
+  def newMember(model: M, userId: ObjectReference): MemberType
 
   /**
     * Returns all members of the model. This includes members that have not
@@ -55,24 +51,14 @@ abstract class MembershipDossier[ModelType <: Model](val model: ModelType) {
     *
     * @return All members
     */
-  def members(implicit ec: ExecutionContext, service: ModelService): Future[Set[MemberType]] =
-    this.association.all.map(_.map { user =>
-      newMember(user.id.value)
-    })
+  def members(model: M): F[Set[MemberType]]
 
   /**
     * Adds a new role to the dossier and adds the user as a member if not already.
     *
     * @param role Role to add
     */
-  def addRole(role: RoleType)(implicit ec: ExecutionContext, service: ModelService): Future[RoleType] = {
-    for {
-      user   <- role.user
-      exists <- this.roles.exists(_.userId === user.id.value)
-      _      <- if (!exists) addMember(user) else Future.successful(user)
-      ret    <- this.roleAccess.add(role)
-    } yield ret
-  }
+  def addRole(model: M, role: RoleType): F[RoleType]
 
   /**
     * Returns all roles for the specified [[User]].
@@ -80,8 +66,7 @@ abstract class MembershipDossier[ModelType <: Model](val model: ModelType) {
     * @param user User to get roles for
     * @return     User roles
     */
-  def getRoles(user: User)(implicit ec: ExecutionContext, service: ModelService): Future[Set[RoleType]] =
-    this.roles.filter(_.userId === user.id.value).map(_.toSet)
+  def getRoles(model: M, user: User): F[Set[RoleType]]
 
   /**
     * Returns the highest level of [[ore.permission.role.Trust]] this user has.
@@ -89,21 +74,14 @@ abstract class MembershipDossier[ModelType <: Model](val model: ModelType) {
     * @param user User to get trust of
     * @return Trust of user
     */
-  def getTrust(user: User)(implicit ex: ExecutionContext): Future[Trust]
+  def getTrust(model: M, user: User): F[Trust]
 
   /**
     * Removes a role from the dossier and removes the member if last role.
     *
     * @param role Role to remove
     */
-  def removeRole(role: RoleType)(implicit ec: ExecutionContext, service: ModelService): Future[Unit] = {
-    for {
-      _      <- this.roleAccess.remove(role)
-      user   <- role.user
-      exists <- this.roles.exists(_.userId === user.id.value)
-      _      <- if (!exists) removeMember(user) else Future.successful(0)
-    } yield ()
-  }
+  def removeRole(model: M, role: RoleType): F[Unit]
 
   /**
     * Clears all user roles and removes the user from the dossier.
@@ -111,14 +89,116 @@ abstract class MembershipDossier[ModelType <: Model](val model: ModelType) {
     * @param user User to remove
     * @return
     */
-  def removeMember(user: User)(implicit ec: ExecutionContext, service: ModelService): Future[Int] =
-    clearRoles(user).flatMap { _ =>
-      this.association.remove(user)
-    }
-
+  def removeMember(model: M, user: User): F[Int]
 }
 
 object MembershipDossier {
+
+  type Aux[F[_], M <: Model, RoleType0 <: RoleModel, MemberType0 <: Member[RoleType0]] = MembershipDossier[F, M] {
+    type RoleType   = RoleType0
+    type MemberType = MemberType0
+  }
+
+  def apply[F[_], M <: Model](
+      implicit dossier: MembershipDossier[F, M]
+  ): Aux[F, M, dossier.RoleType, dossier.MemberType] = dossier
+
+  abstract class AbstractMembershipDossier[
+      M0 <: Model { type M = M0 },
+      RoleType0 <: RoleModel,
+      MembersTable <: AssociativeTable
+  ](
+      roleClass: Class[RoleType0],
+      membersTableClass: Class[MembersTable]
+  )(
+      implicit ec: ExecutionContext,
+      service: ModelService
+  ) extends MembershipDossier[Future, M0] {
+
+    type RoleType = RoleType0
+
+    private def association(model: M0) =
+      model.schema.getAssociation[MembersTable, User](membersTableClass, model)
+
+    private def addMember(model: M0, user: User) =
+      association(model).add(user)
+
+    def roles(model: M0): ModelAccess[RoleType] =
+      model.schema.getChildren(roleClass, model)
+
+    def roleAccess: ModelAccess[RoleType] =
+      service.access(roleClass)
+
+    def members(model: M0): Future[Set[MemberType]] =
+      association(model).all.map(_.map { user =>
+        newMember(model, user.id.value)
+      })
+
+    def addRole(model: M0, role: RoleType): Future[RoleType] = {
+      for {
+        user   <- role.user
+        exists <- roles(model).exists(_.userId === user.id.value)
+        _      <- if (!exists) addMember(model, user) else Future.successful(user)
+        ret    <- roleAccess.add(role)
+      } yield ret
+    }
+
+    def getRoles(model: M0, user: User): Future[Set[RoleType]] =
+      roles(model).filter(_.userId === user.id.value).map(_.toSet)
+
+    def removeRole(model: M0, role: RoleType): Future[Unit] = {
+      for {
+        _      <- roleAccess.remove(role)
+        user   <- role.user
+        exists <- roles(model).exists(_.userId === user.id.value)
+        _      <- if (!exists) removeMember(model, user) else Future.successful(0)
+      } yield ()
+    }
+
+    def removeMember(model: M0, user: User): Future[Int] =
+      clearRoles(model, user) *> association(model).remove(user)
+  }
+
+  implicit def project(
+      implicit ec: ExecutionContext,
+      service: ModelService
+  ): Aux[Future, Project, ProjectRole, ProjectMember] =
+    new AbstractMembershipDossier[Project, ProjectRole, ProjectMembersTable](
+      classOf[ProjectRole],
+      classOf[ProjectMembersTable]
+    ) {
+      override type MemberType = ProjectMember
+
+      override def newMember(model: Project, userId: ObjectReference): ProjectMember = new ProjectMember(model, userId)
+
+      override def getTrust(model: Project, user: User): Future[Trust] =
+        service
+          .doAction(Project.roleForTrustQuery((model.id.value, user.id.value)).result)
+          .map(l => if (l.isEmpty) Default else l.map(_.trust).max)
+
+      override def clearRoles(model: Project, user: User): Future[Int] =
+        this.roleAccess.removeAll(s => (s.userId === user.id.value) && (s.projectId === model.id.value))
+    }
+
+  implicit def organization(
+      implicit ec: ExecutionContext,
+      service: ModelService
+  ): Aux[Future, Organization, OrganizationRole, OrganizationMember] =
+    new AbstractMembershipDossier[Organization, OrganizationRole, OrganizationMembersTable](
+      classOf[OrganizationRole],
+      classOf[OrganizationMembersTable]
+    ) {
+      override type MemberType = OrganizationMember
+
+      override def newMember(model: Organization, userId: ObjectReference): OrganizationMember =
+        new OrganizationMember(model, userId)
+
+      override def getTrust(model: Organization, user: User): Future[Trust] =
+        Organization.getTrust(user.id.value, model.id.value)
+
+      override def clearRoles(model: Organization, user: User): Future[Int] =
+        this.roleAccess.removeAll(s => (s.userId === user.id.value) && (s.organizationId === model.id.value))
+    }
 
   val STATUS_DECLINE  = "decline"
   val STATUS_ACCEPT   = "accept"


### PR DESCRIPTION
Makes `MembershipDossier` a typeclass. I still hate that system, but I hope this will make it slightly better. Not committing to any syntax ops yet as I want to redo the entire membership thingy at some point.

Usage should be the same for the most part, except that some methods on the object now takes the model that is being handled.

Also rewrote it to potentially handle other effect types, although Future is pretty locked in at the moment.