### PR TITLE
Changes to the logback configuration

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -15,6 +15,11 @@
         <appender-ref ref="Console" />
     </appender>
 
+    <root level="WARN">
+        <appender-ref ref="Sentry" />
+        <appender-ref ref="AsyncConsole" />
+    </root>
+
     <!-- Sentry -->
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
@@ -22,10 +27,14 @@
         </filter>
     </appender>
 
-    <root level="WARN">
-        <appender-ref ref="Sentry" />
-        <appender-ref ref="AsyncConsole" />
-    </root>
+    <!-- Disables the security logger -->
+    <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
+        <Marker>SECURITY</Marker>
+        <OnMatch>DENY</OnMatch>
+    </turboFilter>
+
+    <!-- Shutdown gracefully -->
+    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
 
     <!-- Play -->
     <logger name="play" level="INFO" />

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -15,17 +15,17 @@
         <appender-ref ref="Console" />
     </appender>
 
-    <root level="WARN">
-        <appender-ref ref="Sentry" />
-        <appender-ref ref="AsyncConsole" />
-    </root>
-
     <!-- Sentry -->
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>
     </appender>
+
+    <root level="WARN">
+        <appender-ref ref="Sentry" />
+        <appender-ref ref="AsyncConsole" />
+    </root>
 
     <!-- Disables the security logger -->
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">


### PR DESCRIPTION
- Disables the security filter since it only produces warnings which lead to nothing in production. See https://sentry.io/sponge/ore/?query=logback-Marker%3A%22SECURITY%22
- Adds graceful shutdown for logback