### PR TITLE
Add link icon on hover to links on markdown headers

### DIFF
--- a/app/assets/stylesheets/_editor.scss
+++ b/app/assets/stylesheets/_editor.scss
@@ -39,6 +39,30 @@
     border-bottom: 1px solid $lighter;
     padding-bottom: 5px;
   }
+
+  .headeranchor {
+    display: none;
+    text-decoration: none;
+  }
+
+  h1:hover, h2:hover, h3:hover {
+    .headeranchor {
+      display: inline-block;
+      font-size: 16px;
+      margin-left: -18px;
+      width: 18px;
+    }
+  }
+
+  h4:hover, h5:hover, h6:hover {
+    .headeranchor {
+      display: inline-block;
+      font-size: 12px;
+      margin-left: -12px;
+      width: 12px;
+    }
+  }
+
 }
 
 button.open:hover {

--- a/app/models/project/Page.scala
+++ b/app/models/project/Page.scala
@@ -170,6 +170,8 @@ object Page extends DefaultModelCompanion[Page, PageTable](TableQuery[PageTable]
   private lazy val (markdownParser, htmlRenderer) = {
     val options = new MutableDataSet()
       .set[java.lang.Boolean](HtmlRenderer.SUPPRESS_HTML, true)
+      .set[java.lang.String](AnchorLinkExtension.ANCHORLINKS_TEXT_PREFIX, "<i class=\"fas fa-link\"></i>")
+      .set[java.lang.String](AnchorLinkExtension.ANCHORLINKS_ANCHOR_CLASS, "headeranchor")
       .set[java.lang.Boolean](AnchorLinkExtension.ANCHORLINKS_WRAP_TEXT, false)
 
       // GFM table compatibility


### PR DESCRIPTION
See image:
![image](https://user-images.githubusercontent.com/1497508/53308198-18df1100-3897-11e9-80d3-53194c648659.png)
Link icon is visible when hovering over the heading.