### PR TITLE
Improve and fix download warnings

### DIFF
--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -719,7 +719,9 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
               )
             } else {
               version.channel.map(_.isNonReviewed).map { nonReviewed =>
-                MultipleChoices(views.unsafeDownload(project, version, nonReviewed, dlType))
+                //We return Ok here to make sure Chrome sets the cookie
+                //https://bugs.chromium.org/p/chromium/issues/detail?id=696204
+                Ok(views.unsafeDownload(project, version, nonReviewed, dlType))
                   .addingToSession(DownloadWarning.cookieKey(version.id) -> "set")
               }
             }

--- a/app/controllers/project/Versions.scala
+++ b/app/controllers/project/Versions.scala
@@ -11,7 +11,7 @@ import scala.concurrent.ExecutionContext
 import play.api.cache.AsyncCacheApi
 import play.api.i18n.{Lang, MessagesApi}
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, Request, Result}
+import play.api.mvc.{Action, AnyContent, Result}
 import play.filters.csrf.CSRF
 
 import controllers.OreBaseController
@@ -20,7 +20,7 @@ import controllers.sugar.Requests.{AuthRequest, OreRequest, ProjectRequest}
 import db.access.ModelView
 import db.impl.OrePostgresDriver.api._
 import db.impl.schema.UserTable
-import db.{Model, DbRef, ModelService}
+import db.{DbRef, Model, ModelService}
 import form.OreForms
 import models.admin.VersionVisibilityChange
 import models.project._
@@ -39,8 +39,8 @@ import views.html.projects.{versions => views}
 
 import cats.data.{EitherT, OptionT}
 import cats.effect.IO
-import cats.syntax.all._
 import cats.instances.option._
+import cats.syntax.all._
 import com.github.tminglei.slickpg.InetString
 import com.typesafe.scalalogging
 
@@ -602,19 +602,25 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
     if (version.reviewState == ReviewState.Reviewed)
       IO.pure(true)
     else {
-      // check for confirmation
-      OptionT
-        .fromOption[IO](req.cookies.get(DownloadWarning.COOKIE + "_" + version.id).map(_.value).orElse(token))
-        .flatMap { tkn =>
-          ModelView.now(DownloadWarning).find { warn =>
-            (warn.token === tkn) &&
-            (warn.versionId === version.id.value) &&
-            (warn.address === InetString(StatTracker.remoteAddress)) &&
-            warn.isConfirmed
+      val hasSessionConfirm = req.session.get(DownloadWarning.cookieKey(version.id)).contains("confirmed")
+
+      if (hasSessionConfirm) {
+        IO.pure(true)
+      } else {
+        // check confirmation for API
+        OptionT
+          .fromOption[IO](token)
+          .flatMap { tkn =>
+            ModelView.now(DownloadWarning).find { warn =>
+              (warn.token === tkn) &&
+              (warn.versionId === version.id.value) &&
+              (warn.address === InetString(StatTracker.remoteAddress)) &&
+              warn.isConfirmed
+            }
           }
-        }
-        .semiflatMap(warn => if (warn.hasExpired) service.delete(warn).as(false) else IO.pure(true))
-        .exists(identity)
+          .semiflatMap(warn => if (warn.hasExpired) service.delete(warn).as(false) else IO.pure(true))
+          .exists(identity)
+      }
     }
   }
 
@@ -665,7 +671,7 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
           val address    = InetString(StatTracker.remoteAddress)
           // remove old warning attached to address that are expired (or duplicated for version)
           val removeWarnings = service.deleteWhere(DownloadWarning) { warning =>
-            (warning.address === address && warning.expiration < new Timestamp(new Date().getTime)) || warning.versionId === version.id.value
+            (warning.address === address || warning.expiration < new Timestamp(new Date().getTime)) && warning.versionId === version.id.value
           }
           // create warning
           val addWarning = service.insert(
@@ -673,26 +679,26 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
               expiration = expiration,
               token = token,
               versionId = version.id,
-              address = InetString(StatTracker.remoteAddress),
+              address = address,
               downloadId = None
             )
           )
 
-          val isPartial = version.reviewState == ReviewState.PartiallyReviewed
-          val apiMsg =
-            if (isPartial) "version.download.confirmPartial.body.api" else "version.download.confirm.body.api"
+          val isPartial   = version.reviewState == ReviewState.PartiallyReviewed
+          val apiMsgKey   = if (isPartial) "version.download.confirmPartial.api" else "version.download.confirm.body.api"
+          lazy val apiMsg = this.messagesApi(apiMsgKey)
 
           if (api.getOrElse(false)) {
-            (removeWarnings *> addWarning).as {
+            (removeWarnings *> addWarning).as(
               MultipleChoices(
                 Json.obj(
-                  "message" -> this.messagesApi(apiMsg).split('\n'),
-                  "post"    -> self.confirmDownload(author, slug, target, Some(dlType.value), token).absoluteURL(),
+                  "message" -> apiMsg,
+                  "post"    -> self.confirmDownload(author, slug, target, Some(dlType.value), Some(token)).absoluteURL(),
                   "url"     -> self.downloadJarById(project.pluginId, version.name, Some(token)).absoluteURL(),
                   "token"   -> token
                 )
               )
-            }
+            )
           } else {
             val userAgent = request.headers.get("User-Agent").map(_.toLowerCase)
 
@@ -702,19 +708,19 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
                   .withHeaders("Content-Disposition" -> "inline; filename=\"README.txt\"")
               )
             } else if (userAgent.exists(_.startsWith("curl/"))) {
-              IO.pure(
+              (removeWarnings *> addWarning).as(
                 MultipleChoices(
-                  this.messagesApi(
-                    apiMsg,
-                    self.confirmDownload(author, slug, target, Some(dlType.value), token).absoluteURL(),
+                  apiMsg + "\n" + this.messagesApi(
+                    "version.download.confirm.curl",
+                    self.confirmDownload(author, slug, target, Some(dlType.value), Some(token)).absoluteURL(),
                     CSRF.getToken.get.value
                   ) + "\n"
                 ).withHeaders("Content-Disposition" -> "inline; filename=\"README.txt\"")
               )
             } else {
-              (removeWarnings *> addWarning, version.channel.map(_.isNonReviewed)).parMapN { (warn, nonReviewed) =>
-                MultipleChoices(views.unsafeDownload(project, version, nonReviewed, dlType, token))
-                  .withCookies(warn.cookie)
+              version.channel.map(_.isNonReviewed).map { nonReviewed =>
+                MultipleChoices(views.unsafeDownload(project, version, nonReviewed, dlType))
+                  .addingToSession(DownloadWarning.cookieKey(version.id) -> "set")
               }
             }
           }
@@ -727,7 +733,7 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
       slug: String,
       target: String,
       downloadType: Option[Int],
-      token: String
+      token: Option[String]
   ): Action[AnyContent] = {
     ProjectAction(author, slug).asyncEitherT { implicit request =>
       getVersion(request.data.project, target)
@@ -738,14 +744,16 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
           confirmDownload0(version.id, downloadType, token)
             .toRight(Redirect(ShowProject(author, slug)).withError("error.plugin.noConfirmDownload"))
         }
-        .map { dl =>
-          dl.downloadType match {
-            case UploadedFile => Redirect(self.download(author, slug, target, Some(token)))
-            case JarFile      => Redirect(self.downloadJar(author, slug, target, Some(token)))
-            // Note: Shouldn't get here in the first place since sig files
-            // don't need confirmation, but added as a failsafe.
-            case SignatureFile => Redirect(self.downloadSignature(author, slug, target))
-          }
+        .map {
+          case (dl, optNewSession) =>
+            val newSession = optNewSession.getOrElse(request.session)
+            dl.downloadType match {
+              case UploadedFile => Redirect(self.download(author, slug, target, token)).withSession(newSession)
+              case JarFile      => Redirect(self.downloadJar(author, slug, target, token)).withSession(newSession)
+              // Note: Shouldn't get here in the first place since sig files
+              // don't need confirmation, but added as a failsafe.
+              case SignatureFile => Redirect(self.downloadSignature(author, slug, target)).withSession(newSession)
+            }
         }
     }
   }
@@ -753,43 +761,53 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
   /**
     * Confirms the download and prepares the unsafe download.
     */
-  private def confirmDownload0(versionId: DbRef[Version], downloadType: Option[Int], token: String)(
-      implicit requestHeader: Request[_],
-      mdc: OreMDC
-  ): OptionT[IO, UnsafeDownload] = {
+  private def confirmDownload0(versionId: DbRef[Version], downloadType: Option[Int], optToken: Option[String])(
+      implicit request: OreRequest[_]
+  ): OptionT[IO, (Model[UnsafeDownload], Option[play.api.mvc.Session])] = {
     val addr = InetString(StatTracker.remoteAddress)
     val dlType = downloadType
       .flatMap(DownloadType.withValueOpt)
       .getOrElse(DownloadType.UploadedFile)
-    // find warning
-    ModelView
-      .now(DownloadWarning)
-      .find { warn =>
-        (warn.address === addr) &&
-        (warn.token === token) &&
-        (warn.versionId === versionId) &&
-        !warn.isConfirmed &&
-        warn.downloadId.?.isEmpty
-      }
-      .semiflatMap { warn =>
-        val isInvalid = warn.hasExpired
-        // warning has expired
-        val remove = if (isInvalid) service.delete(warn).void else IO.unit
 
-        remove.as((warn, isInvalid))
-      }
-      .filterNot(_._2)
-      .map(_._1)
-      .semiflatMap { warn =>
-        // warning confirmed and redirect to download
-        for {
-          user <- users.current.value
-          unsafeDownload <- service.insert(
-            UnsafeDownload(userId = user.map(_.id.value), address = addr, downloadType = dlType)
-          )
-          _ <- service.update(warn)(_.copy(isConfirmed = true, downloadId = Some(unsafeDownload.id)))
-        } yield unsafeDownload
-      }
+    val user = request.currentUser
+
+    val insertDownload = service.insert(
+      UnsafeDownload(userId = user.map(_.id.value), address = addr, downloadType = dlType)
+    )
+
+    optToken match {
+      case None =>
+        val cookieKey    = DownloadWarning.cookieKey(versionId)
+        val sessionIsSet = request.session.get(cookieKey).contains("set")
+
+        if (sessionIsSet) {
+          val newSession = request.session + (cookieKey -> "confirmed")
+          OptionT.liftF(insertDownload.tupleRight(Some(newSession)))
+        } else {
+          OptionT.none[IO, (Model[UnsafeDownload], Option[play.api.mvc.Session])]
+        }
+      case Some(token) =>
+        // find warning
+        ModelView
+          .now(DownloadWarning)
+          .find { warn =>
+            (warn.address === addr) &&
+            (warn.token === token) &&
+            (warn.versionId === versionId) &&
+            !warn.isConfirmed &&
+            warn.downloadId.?.isEmpty
+          }
+          .flatMapF { warn =>
+            if (warn.hasExpired) service.delete(warn).as(None) else IO.pure(Some(warn))
+          }
+          .semiflatMap { warn =>
+            // warning confirmed and redirect to download
+            for {
+              unsafeDownload <- insertDownload
+              _              <- service.update(warn)(_.copy(isConfirmed = true, downloadId = Some(unsafeDownload.id)))
+            } yield (unsafeDownload, None)
+          }
+    }
   }
 
   /**
@@ -916,7 +934,7 @@ class Versions @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
       getVersion(project, versionString).semiflatMap { version =>
         optToken
           .map { token =>
-            confirmDownload0(version.id, Some(JarFile.value), token).value *>
+            confirmDownload0(version.id, Some(JarFile.value), Some(token)).value *>
               sendJar(project, version, optToken, api = true)
           }
           .getOrElse(sendJar(project, version, optToken, api = true))

--- a/app/models/project/DownloadWarning.scala
+++ b/app/models/project/DownloadWarning.scala
@@ -2,16 +2,11 @@ package models.project
 
 import java.sql.Timestamp
 
-import play.api.mvc.Cookie
-
-import controllers.sugar.Bakery
 import db.impl.model.common.Expirable
 import db.impl.schema.DownloadWarningsTable
 import db.{DbRef, DefaultModelCompanion, ModelQuery}
-import models.project.DownloadWarning.COOKIE
 
 import com.github.tminglei.slickpg.InetString
-import com.google.common.base.Preconditions._
 import slick.lifted.TableQuery
 
 /**
@@ -31,18 +26,7 @@ case class DownloadWarning(
     address: InetString,
     isConfirmed: Boolean = false,
     downloadId: Option[DbRef[UnsafeDownload]]
-) extends Expirable {
-
-  /**
-    * Creates a cookie that should be given to the client.
-    *
-    * @return Cookie for client
-    */
-  def cookie(implicit bakery: Bakery): Cookie = {
-    checkNotNull(this.token, "null token", "")
-    bakery.bake(COOKIE + "_" + this.versionId, this.token)
-  }
-}
+) extends Expirable
 
 object DownloadWarning
     extends DefaultModelCompanion[DownloadWarning, DownloadWarningsTable](TableQuery[DownloadWarningsTable]) {
@@ -50,9 +34,6 @@ object DownloadWarning
   implicit val query: ModelQuery[DownloadWarning] =
     ModelQuery.from(this)
 
-  /**
-    * Cookie identifier name.
-    */
-  val COOKIE = "_warning"
+  def cookieKey(versionId: DbRef[Version]) = s"_warning_$versionId"
 
 }

--- a/app/views/projects/versions/unsafeDownload.scala.html
+++ b/app/views/projects/versions/unsafeDownload.scala.html
@@ -6,8 +6,7 @@
 @(project: Project,
         target: Version,
         isTargetChannelNonReviewed: Boolean,
-        downloadType: DownloadType,
-        token: String)(implicit messages: Messages, request: OreRequest[_], config: OreConfig, flash: Flash)
+        downloadType: DownloadType)(implicit messages: Messages, request: OreRequest[_], config: OreConfig, flash: Flash)
 
 @versionRoutes = @{ controllers.project.routes.Versions }
 
@@ -49,7 +48,7 @@
                         </div>
 
                         <div class="col-xs-12 col-sm-6">
-                            <form action="@versionRoutes.confirmDownload(project.ownerName, project.slug, target.name, Some(downloadType.value), token)" method="post" id="form-download">
+                            <form action="@versionRoutes.confirmDownload(project.ownerName, project.slug, target.name, Some(downloadType.value), None)" method="post" id="form-download">
                                 @CSRF.formField
 
                                 <button type="submit" form="form-download" class="btn btn-danger pull-right-sm">

--- a/app/views/projects/versions/unsafeDownload.scala.html
+++ b/app/views/projects/versions/unsafeDownload.scala.html
@@ -48,7 +48,7 @@
                         </div>
 
                         <div class="col-xs-12 col-sm-6">
-                            <form action="@versionRoutes.confirmDownload(project.ownerName, project.slug, target.name, Some(downloadType.value), None)" method="post" id="form-download">
+                            <form action="@versionRoutes.confirmDownload(project.ownerName, project.slug, target.name, Some(downloadType.value), None, Some("dummy"))" method="post" id="form-download">
                                 @CSRF.formField
 
                                 <button type="submit" form="form-download" class="btn btn-danger pull-right-sm">

--- a/conf/messages
+++ b/conf/messages
@@ -254,15 +254,17 @@ version.download.confirm.download               =   Download it at my own risk
 version.download.confirm.body.api = \
   This version has not been reviewed by our moderation staff and may not be safe for download.\n\
   Disclaimer: We disclaim all responsibility for any harm to your server or system should you choose not to heed this \
-  warning.\n\
-  Please POST to the attached link to acknowledge this disclaimer and continue to the download.
+  warning.
 
-version.download.confirmPartial.body.api = \
+version.download.confirmPartial.api = \
   This version has only been partially reviewed by our moderation staff and may not be safe for download.\
   While the core plugin has been reviewed, other resources like shaded libraries have not. \n\
   Disclaimer: We disclaim all responsibility for any harm to your server or system should you choose not to heed this \
-  warning.\n\
-  Please POST to the attached link to acknowledge this disclaimer and continue to the download.
+  warning.
+
+version.download.confirm.curl = \
+  Please POST to the attached link to acknowledge this disclaimer and continue to the download. \
+  curl -O -J -L -d -X "{0}&csrfToken={1}"
 
 version.download.confirm.wget = Sorry, but Ore does not support the use of wget. \
   Please use the following curl instead:\n\

--- a/conf/routes
+++ b/conf/routes
@@ -174,7 +174,7 @@ POST    /:author/:slug/versions/:version/delete                     @controllers
 
 GET     /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.showDownloadConfirm(author, slug, version, downloadType: Option[Int], api: Option[Boolean])
 +nocsrf
-POST    /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.confirmDownload(author, slug, version, downloadType: Option[Int], token)
+POST    /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.confirmDownload(author, slug, version, downloadType: Option[Int], token: Option[String])
 
 GET     /:author/:slug/versions/recommended/download                @controllers.project.Versions.downloadRecommended(author, slug, token: Option[String])
 GET     /:author/:slug/versions/recommended/signature               @controllers.project.Versions.downloadRecommendedSignature(author, slug)

--- a/conf/routes
+++ b/conf/routes
@@ -172,9 +172,9 @@ POST    /:author/:slug/versions/:version/hardDelete                 @controllers
 POST    /:author/:slug/versions/:version/restore                    @controllers.project.Versions.restore(author, slug, version)
 POST    /:author/:slug/versions/:version/delete                     @controllers.project.Versions.softDelete(author, slug, version)
 
-GET     /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.showDownloadConfirm(author, slug, version, downloadType: Option[Int], api: Option[Boolean])
+GET     /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.showDownloadConfirm(author, slug, version, downloadType: Option[Int], api: Option[Boolean], dummy: Option[String])
 +nocsrf
-POST    /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.confirmDownload(author, slug, version, downloadType: Option[Int], token: Option[String])
+POST    /:author/:slug/versions/:version/confirm                    @controllers.project.Versions.confirmDownload(author, slug, version, downloadType: Option[Int], token: Option[String], dummy: Option[String])
 
 GET     /:author/:slug/versions/recommended/download                @controllers.project.Versions.downloadRecommended(author, slug, token: Option[String])
 GET     /:author/:slug/versions/recommended/signature               @controllers.project.Versions.downloadRecommendedSignature(author, slug)


### PR DESCRIPTION
Various fixes and improvements to download warnings. For normal users, the currently accepted versions are stored in the play session. For API stuff, the token is now actually inserted into the DB, in addition to showing the curl link again.

Closes #763