### PR TITLE
Fixed KEY_ENTER variable to be only defined once

### DIFF
--- a/ore/public/javascripts/pageEdit.js
+++ b/ore/public/javascripts/pageEdit.js
@@ -1,6 +1,5 @@
 //=====> EXTERNAL CONSTANTS
 
-var KEY_ENTER = 13;
 var PROJECT_OWNER = null;
 var PROJECT_SLUG = null;
 

--- a/ore/public/javascripts/userSearch.js
+++ b/ore/public/javascripts/userSearch.js
@@ -1,8 +1,3 @@
-//=====> CONSTANTS
-
-var KEY_ENTER = 13;
-
-
 //=====> HELPER FUNCTIONS
 
 function initUserSearch(callback) {


### PR DESCRIPTION
`KEY_ENTER` is definde in `main.js` which is included in any page.
I changed `KEY_ENTER` to `const` in which breaks all pages with doubled definition.