### PR TITLE
Resolve the icon url for a project statically

### DIFF
--- a/ore/app/controllers/project/Projects.scala
+++ b/ore/app/controllers/project/Projects.scala
@@ -340,14 +340,11 @@ class Projects @Inject()(stats: StatTracker, forms: OreForms, factory: ProjectFa
     * @return Project icon
     */
   def showIcon(author: String, slug: String): Action[AnyContent] = Action.asyncF {
-    // TODO maybe instead of redirect cache this on ore?
     projects
       .withSlug(author, slug)
       .map { project =>
-        projects.fileManager.getIconPath(project)(OreMDC.NoMDC) match {
-          case None           => Redirect(User.avatarUrl(project.ownerName))
-          case Some(iconPath) => showImage(iconPath)
-        }
+        implicit val mdc: OreMDC.NoMDC.type = OreMDC.NoMDC
+        project.obj.iconUrlOrPath.fold(Redirect(_), showImage)
       }
       .getOrElse(NotFound)
   }

--- a/ore/app/views/home.scala.html
+++ b/ore/app/views/home.scala.html
@@ -16,10 +16,11 @@ sorted according to different criteria.
 @import ore.data.Platform
 @import ore.data.PlatformCategory
 @import ore.data.project.Category
+@import db.impl.access.ProjectBase
 @(models: Seq[ProjectListEntry], visibleCategories: Option[Seq[Category]], query: Option[String], page: Int,
         sort: ProjectSortingStrategy, platformCategory: Option[PlatformCategory], platform: Option[Platform],
         orderWithRelevance: Boolean, totalProjects: Int)(implicit messages: Messages, flash: Flash,
-        request: OreRequest[_], config: OreConfig)
+        request: OreRequest[_], config: OreConfig, projectBase: ProjectBase)
 
 @randomSponsor = @{
     val logos = config.sponge.sponsors

--- a/ore/app/views/projects/discuss.scala.html
+++ b/ore/app/views/projects/discuss.scala.html
@@ -8,7 +8,10 @@ Discussion page within Project overview.
 
 @import views.html.helper.CSPNonce
 @import ore.markdown.MarkdownRenderer
-@(p: ProjectData, sp: ScopedProjectData, forumsAvailable: Boolean)(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer)
+@import db.impl.access.ProjectBase
+
+@(p: ProjectData, sp: ScopedProjectData, forumsAvailable: Boolean)(implicit messages: Messages, request: OreRequest[_],
+        flash: Flash, config: OreConfig, renderer: MarkdownRenderer, projectBase: ProjectBase)
 
 @projectRoutes = @{controllers.project.routes.Projects}
 

--- a/ore/app/views/projects/list.scala.html
+++ b/ore/app/views/projects/list.scala.html
@@ -8,10 +8,21 @@ Collection of all projects.
 @import models.querymodels.{ProjectListEntry, ViewTag}
 @import util.syntax._
 @import views.html.utils
-@(models: Seq[ProjectListEntry], page: Int, pageSize: Long, call: Int => Call)(implicit config: OreConfig)
+@import db.impl.access.ProjectBase
+@import ore.util.OreMDC
+@(models: Seq[ProjectListEntry], page: Int, pageSize: Long, call: Int => Call)(implicit config: OreConfig, projectBase: ProjectBase, mdc: OreMDC)
 
 @projectRoutes = @{
     controllers.project.routes.Projects
+}
+
+@entryIcon(entry: ProjectListEntry) = @{
+    if(projectBase.fileManager.getIconPath(entry.namespace.ownerName, entry.name).isDefined) {
+        projectRoutes.showIcon(entry.namespace.ownerName, entry.namespace.slug).url
+    }
+    else {
+        User.avatarUrl(entry.namespace.ownerName)
+    }
 }
 
 <ul class="list-group project-list">
@@ -23,7 +34,7 @@ Collection of all projects.
                     @utils.userAvatar(
                         userName = Some(entry.namespace.ownerName),
                         avatarUrl = User.avatarUrl(entry.namespace.ownerName),
-                        call = projectRoutes.showIcon(entry.namespace.ownerName, entry.namespace.slug),
+                        imgSrc = entryIcon(entry),
                         clazz = "user-avatar-sm")
                     </div>
                     <div class="col-xs-12 col-sm-11">

--- a/ore/app/views/projects/pages/view.scala.html
+++ b/ore/app/views/projects/pages/view.scala.html
@@ -17,13 +17,14 @@ Documentation page within Project overview.
 @import ore.markdown.MarkdownRenderer
 @import util.syntax._
 
+@import db.impl.access.ProjectBase
 @(p: ProjectData,
   sp: ScopedProjectData,
   rootPages: Seq[(Model[Page], Seq[Page])],
   page: Page,
   parentPage: Option[Page],
   pageCount: Int,
-  editorOpen: Boolean = false)(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer)
+  editorOpen: Boolean = false)(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer, projectBase: ProjectBase)
 
 @canEditPages = @{
     sp.perms(Permission.EditPage)

--- a/ore/app/views/projects/settings.scala.html
+++ b/ore/app/views/projects/settings.scala.html
@@ -8,9 +8,12 @@
 @import ore.permission.Permission
 @import ore.markdown.MarkdownRenderer
 @import ore.models.api.ProjectApiKey
+@import ore.util.OreMDC
+@import db.impl.access.ProjectBase
 @import util.syntax._
 
-@(p: ProjectData, sp: ScopedProjectData, deploymentKey: Option[Model[ProjectApiKey]])(implicit messages: Messages, flash: Flash, request: OreRequest[_], config: OreConfig, renderer: MarkdownRenderer)
+@(p: ProjectData, sp: ScopedProjectData, deploymentKey: Option[Model[ProjectApiKey]])(implicit messages: Messages, flash: Flash,
+        request: OreRequest[_], config: OreConfig, renderer: MarkdownRenderer, projectBase: ProjectBase, mdc: OreMDC)
 
 @projectRoutes = @{controllers.project.routes.Projects}
 
@@ -102,7 +105,7 @@
                                 @utils.userAvatar(
                                     Some(p.projectOwner.name),
                                     p.projectOwner.avatarUrl,
-                                    call = projectRoutes.showIcon(p.project.ownerName, p.project.slug),
+                                    imgSrc = p.project.obj.iconUrl,
                                     clazz = "user-avatar-md")
 
                                 <input class="form-control-static" type="file" id="icon" name="icon" />

--- a/ore/app/views/projects/stargazers.scala.html
+++ b/ore/app/views/projects/stargazers.scala.html
@@ -8,7 +8,9 @@
 @import util.syntax._
 
 @import ore.markdown.MarkdownRenderer
-@(p: ProjectData, sp: ScopedProjectData, users: Seq[User], page: Int, pageSize: Int)(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer)
+@import db.impl.access.ProjectBase
+@(p: ProjectData, sp: ScopedProjectData, users: Seq[User], page: Int, pageSize: Int)(implicit messages: Messages, request: OreRequest[_],
+        flash: Flash, config: OreConfig, renderer: MarkdownRenderer, projectBase: ProjectBase)
 
 @columns = @{
     3

--- a/ore/app/views/projects/versions/list.scala.html
+++ b/ore/app/views/projects/versions/list.scala.html
@@ -8,9 +8,10 @@ Versions page within Project overview.
 @import views.html.helper.CSPNonce
 @import ore.permission.Permission
 @import ore.markdown.MarkdownRenderer
+@import db.impl.access.ProjectBase
 @(p: ProjectData,
         sp: ScopedProjectData,
-        channels: Seq[Channel])(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer)
+        channels: Seq[Channel])(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer, projectBase: ProjectBase)
 
 @projectRoutes = @{ controllers.project.routes.Projects }
 @versionRoutes = @{ controllers.project.routes.Versions }

--- a/ore/app/views/projects/versions/view.scala.html
+++ b/ore/app/views/projects/versions/view.scala.html
@@ -10,7 +10,8 @@
 @import ore.data.Platform
 @import util.syntax._
 
-@(v: VersionData, sp: ScopedProjectData)(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer)
+@import db.impl.access.ProjectBase
+@(v: VersionData, sp: ScopedProjectData)(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer, projectBase: ProjectBase)
 
 @projectRoutes = @{controllers.project.routes.Projects}
 @versionRoutes = @{controllers.project.routes.Versions}

--- a/ore/app/views/projects/view.scala.html
+++ b/ore/app/views/projects/view.scala.html
@@ -12,9 +12,12 @@ Base template for Project overview.
 @import ore.permission.Permission
 @import ore.markdown.MarkdownRenderer
 @import ore.data.project.FlagReason
+@import db.impl.access.ProjectBase
+
 @import util.syntax._
 
-@(p: ProjectData, sp: ScopedProjectData, active: String, noButtons: Boolean = false, additionalScripts: Html = Html(""))(content: Html)(implicit messages: Messages, request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer)
+@(p: ProjectData, sp: ScopedProjectData, active: String, noButtons: Boolean = false, additionalScripts: Html = Html(""))(content: Html)(implicit messages: Messages,
+        request: OreRequest[_], flash: Flash, config: OreConfig, renderer: MarkdownRenderer, projectBase: ProjectBase)
 
 @appRoutes = @{controllers.routes.Application}
 
@@ -32,7 +35,7 @@ Base template for Project overview.
     <meta property="og:title" content="@p.project.ownerName / @p.project.name" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="@config.app.baseUrl@Projects.show(p.project.ownerName, p.project.slug)" />
-    <meta property="og:image" content="@config.app.baseUrl@Projects.showIcon(p.project.ownerName, p.project.slug)" />
+    <meta property="og:image" content="@p.project.obj.iconUrl" />
     <meta property="og:site_name" content="@messages("general.appName")" />
     @defining(p.project.description.getOrElse("")) { description =>
         <meta property="og:description" content="@description" />

--- a/ore/app/views/users/projects.scala.html
+++ b/ore/app/views/users/projects.scala.html
@@ -11,8 +11,9 @@
 @import models.querymodels.ProjectListEntry
 @import ore.permission.Permission
 @import util.syntax._
+@import db.impl.access.ProjectBase
 @(u: UserData, o: Option[(OrganizationData, ScopedOrganizationData)], models: Seq[ProjectListEntry], starred: Seq[(Project, Option[Version])],
-        page: Int)(implicit messages: Messages, flash: Flash, request: OreRequest[_], config: OreConfig)
+        page: Int)(implicit messages: Messages, flash: Flash, request: OreRequest[_], config: OreConfig, projectBase: ProjectBase)
 
 @canEditOrgMembers = @{
     u.isOrga &&

--- a/ore/app/views/utils/userAvatar.scala.html
+++ b/ore/app/views/utils/userAvatar.scala.html
@@ -1,13 +1,13 @@
-@(userName: Option[String], avatarUrl: String = "", call: Call = null, clazz: String = "", attr: Map[String, String] = Map(), href: String = null)
+@(userName: Option[String], avatarUrl: String = "", imgSrc: String = null, clazz: String = "", attr: Map[String, String] = Map(), href: String = null)
 
 @src = @{
-    if (call == null) {
+    if (imgSrc == null) {
         if (userName.nonEmpty)
             avatarUrl
         else
             ""
     } else
-        call.url
+        imgSrc
 }
 
 @url = @{

--- a/orePlayCommon/app/ore/models/project/io/ProjectFiles.scala
+++ b/orePlayCommon/app/ore/models/project/io/ProjectFiles.scala
@@ -86,11 +86,21 @@ class ProjectFiles(val env: OreEnv) {
   /**
     * Returns the path to a custom [[Project]] icon, if any, None otherwise.
     *
+    * @param owner  Project owner
+    * @param name   Project name
+    * @return Project icon
+    */
+  def getIconPath(owner: String, name: String)(implicit mdc: OreMDC): Option[Path] =
+    findFirstFile(getIconDir(owner, name))
+
+  /**
+    * Returns the path to a custom [[Project]] icon, if any, None otherwise.
+    *
     * @param project Project to get icon for
     * @return Project icon
     */
   def getIconPath(project: Project)(implicit mdc: OreMDC): Option[Path] =
-    findFirstFile(getIconDir(project.ownerName, project.name))
+    getIconPath(project.ownerName, project.name)
 
   /**
     * Returns the directory that contains an icon that has not yet been saved.

--- a/orePlayCommon/app/util/syntax/ModelSyntax.scala
+++ b/orePlayCommon/app/util/syntax/ModelSyntax.scala
@@ -2,10 +2,13 @@ package util.syntax
 
 import scala.language.{higherKinds, implicitConversions}
 
+import java.nio.file.Path
+
 import play.api.i18n.Lang
+import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 
-import db.impl.access.UserBase
+import db.impl.access.{ProjectBase, UserBase}
 import ore.OreConfig
 import ore.db.access.ModelView
 import ore.db.{DbRef, Model, ModelService}
@@ -32,6 +35,7 @@ trait ModelSyntax {
   implicit def pageSyntax(p: Page): ModelSyntax.PageSyntax                         = new ModelSyntax.PageSyntax(p)
   implicit def pageModelRawSyntax(p: Model[Page]): ModelSyntax.PageSyntax          = new ModelSyntax.PageSyntax(p)
   implicit def pageObjSyntax(p: Page.type): ModelSyntax.PageObjSyntax              = new ModelSyntax.PageObjSyntax(p)
+  implicit def projectSyntax(p: Project): ModelSyntax.ProjectSyntax                = new ModelSyntax.ProjectSyntax(p)
   implicit def projectModelSyntax(p: Model[Project]): ModelSyntax.ProjectModelSyntax =
     new ModelSyntax.ProjectModelSyntax(p)
   implicit def orgSyntax(o: Organization): ModelSyntax.OrganizationSyntax = new ModelSyntax.OrganizationSyntax(o)
@@ -118,6 +122,17 @@ object ModelSyntax extends ModelSyntax {
       * The maximum amount of characters a page may have.
       */
     def maxLengthPage(implicit config: OreConfig): Int = config.ore.pages.pageMaxLen
+  }
+
+  class ProjectSyntax(private val p: Project) extends AnyVal {
+
+    def iconUrlOrPath(implicit projects: ProjectBase, mdc: OreMDC, config: OreConfig): Either[String, Path] =
+      projects.fileManager.getIconPath(p).toRight(User.avatarUrl(p.ownerName))
+
+    def hasIcon(implicit projects: ProjectBase, mdc: OreMDC): Boolean = projects.fileManager.getIconPath(p).isDefined
+
+    def iconUrl(implicit projects: ProjectBase, mdc: OreMDC, header: RequestHeader, config: OreConfig): String =
+      iconUrlOrPath.swap.getOrElse(controllers.project.routes.Projects.showIcon(p.ownerName, p.slug).absoluteURL())
   }
 
   class ProjectModelSyntax(private val p: Model[Project]) extends AnyVal {


### PR DESCRIPTION
Currently when serving icons for projects on Ore, we set the content of the `src` attribute to the ore project icon endpoint. What does this endpoint do? 1. Fetches the project from the DB, 2. Checks if the project has an icon, 3. If it does, sends that, and if not, redirects to auth.

Why is this stupid? Because we have all the information we need already. So, a better approach implemented here, is to check if the project has an icon before generating the link, and only link to the icon endpoint if it does.

This should dramatically reduce the amount of requests needed to render the homepage (if no requests are present, it roughly halves it). It will also reduce the amount if times we hit the DB.