### PR TITLE
Don't show error twice

### DIFF
--- a/ore/app/views/projects/settings.scala.html
+++ b/ore/app/views/projects/settings.scala.html
@@ -219,9 +219,6 @@
 
             <!-- Side panel -->
         <div class="col-md-4">
-            <div class="alert alert-danger" role="alert" @if(flash.get("error").isEmpty) { style="display: none;" }>
-                <strong>Whoops!</strong> <span>@flash.get("error").getOrElse("")</span>
-            </div>
             @users.memberList(p,
                 editable = true,
                 perms = sp.permissions,


### PR DESCRIPTION
Don't show an untranslated error when getting an error when trying to set the settings for a project